### PR TITLE
Updated and split entities to use client methods

### DIFF
--- a/src/Disqord.Rest/Client/Api/RestDiscordAPIClient.cs
+++ b/src/Disqord.Rest/Client/Api/RestDiscordAPIClient.cs
@@ -662,14 +662,14 @@ namespace Disqord.Rest
         public Task CreateGuildBanAsync(ulong guildId, ulong userId, string reason, int? deleteMessageDays, RestRequestOptions options)
         {
             Dictionary<string, object> parameters = null;
-            if (deleteMessageDays != null || reason != null)
+            if (reason != null || deleteMessageDays != null)
             {
                 parameters = new Dictionary<string, object>();
-                if (deleteMessageDays != null)
-                    parameters["delete-message-days"] = deleteMessageDays.Value;
-
                 if (reason != null)
                     parameters["reason"] = reason;
+
+                if (deleteMessageDays != null)
+                    parameters["delete-message-days"] = deleteMessageDays.Value;
             }
             return SendRequestAsync(new RestRequest(PUT, $"guilds/{guildId:guild_id}/bans/{userId}", parameters, options));
         }

--- a/src/Disqord.Rest/Client/Api/RestDiscordAPIClient.cs
+++ b/src/Disqord.Rest/Client/Api/RestDiscordAPIClient.cs
@@ -659,7 +659,7 @@ namespace Disqord.Rest
         public Task<BanModel> GetGuildBanAsync(ulong guildId, ulong userId, RestRequestOptions options)
             => SendRequestAsync<BanModel>(new RestRequest(GET, $"guilds/{guildId:guild_id}/bans/{userId}", options));
 
-        public Task CreateGuildBanAsync(ulong guildId, ulong userId, int? deleteMessageDays, string reason, RestRequestOptions options)
+        public Task CreateGuildBanAsync(ulong guildId, ulong userId, string reason, int? deleteMessageDays, RestRequestOptions options)
         {
             Dictionary<string, object> parameters = null;
             if (deleteMessageDays != null || reason != null)

--- a/src/Disqord.Rest/Client/Rest/RestDiscordClient.Guild.cs
+++ b/src/Disqord.Rest/Client/Rest/RestDiscordClient.Guild.cs
@@ -183,8 +183,8 @@ namespace Disqord.Rest
             }
         }
 
-        public Task BanMemberAsync(Snowflake guildId, Snowflake memberId, int? deleteMessageDays = null, string reason = null, RestRequestOptions options = null)
-            => ApiClient.CreateGuildBanAsync(guildId, memberId, deleteMessageDays, reason, options);
+        public Task BanMemberAsync(Snowflake guildId, Snowflake memberId, string reason = null, int? deleteMessageDays = null, RestRequestOptions options = null)
+            => ApiClient.CreateGuildBanAsync(guildId, memberId, reason, deleteMessageDays, options);
 
         public Task UnbanMemberAsync(Snowflake guildId, Snowflake userId, RestRequestOptions options = null)
             => ApiClient.RemoveGuildBanAsync(guildId, userId, options);

--- a/src/Disqord.Rest/Client/Rest/Undocumented/RestDiscordClient.Relationship.cs
+++ b/src/Disqord.Rest/Client/Rest/Undocumented/RestDiscordClient.Relationship.cs
@@ -13,6 +13,9 @@ namespace Disqord.Rest
             if (type != null && !Enum.IsDefined(typeof(RelationshipType), type.Value))
                 throw new ArgumentOutOfRangeException(nameof(type));
 
+            if (type == RelationshipType.IncomingFriendRequest || type == RelationshipType.OutgoingFriendRequest)
+                throw new ArgumentOutOfRangeException(nameof(type), "The RelationshipType must not be an incoming or outgoing type.");
+
             return ApiClient.CreateRelationshipAsync(userId, type, options);
         }
 

--- a/src/Disqord.Rest/Entities/Core/Client/IRestDiscordClient.Guild.cs
+++ b/src/Disqord.Rest/Entities/Core/Client/IRestDiscordClient.Guild.cs
@@ -45,7 +45,7 @@ namespace Disqord
 
         Task<RestBan> GetBanAsync(Snowflake guildId, Snowflake userId, RestRequestOptions options = null);
 
-        Task BanMemberAsync(Snowflake guildId, Snowflake memberId, int? deleteMessageDays = null, string reason = null, RestRequestOptions options = null);
+        Task BanMemberAsync(Snowflake guildId, Snowflake memberId, string reason = null, int? deleteMessageDays = null, RestRequestOptions options = null);
 
         Task UnbanMemberAsync(Snowflake guildId, Snowflake userId, RestRequestOptions options = null);
 

--- a/src/Disqord.Rest/Entities/Core/Guild/IGuild.Client.cs
+++ b/src/Disqord.Rest/Entities/Core/Guild/IGuild.Client.cs
@@ -44,7 +44,7 @@ namespace Disqord
 
         Task<RestBan> GetBanAsync(Snowflake userId, RestRequestOptions options = null);
 
-        Task BanMemberAsync(Snowflake memberId, int? deleteMessageDays = null, string reason = null, RestRequestOptions options = null);
+        Task BanMemberAsync(Snowflake memberId, string reason = null, int? deleteMessageDays = null, RestRequestOptions options = null);
 
         Task UnbanMemberAsync(Snowflake userId, RestRequestOptions options = null);
 

--- a/src/Disqord.Rest/Entities/Core/Guild/IRole.Client.cs
+++ b/src/Disqord.Rest/Entities/Core/Guild/IRole.Client.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace Disqord
+{
+    public partial interface IRole : ISnowflakeEntity, IMentionable, IDeletable
+    {
+        Task ModifyAsync(Action<ModifyRoleProperties> action, RestRequestOptions options = null);
+    }
+}

--- a/src/Disqord.Rest/Entities/Core/Guild/IRole.cs
+++ b/src/Disqord.Rest/Entities/Core/Guild/IRole.cs
@@ -1,9 +1,6 @@
-﻿using System;
-using System.Threading.Tasks;
-
-namespace Disqord
+﻿namespace Disqord
 {
-    public interface IRole : ISnowflakeEntity, IMentionable, IDeletable
+    public partial interface IRole : ISnowflakeEntity, IMentionable, IDeletable
     {
         string Name { get; }
 
@@ -20,7 +17,5 @@ namespace Disqord
         bool IsMentionable { get; }
 
         Snowflake GuildId { get; }
-
-        Task ModifyAsync(Action<ModifyRoleProperties> action, RestRequestOptions options = null);
     }
 }

--- a/src/Disqord.Rest/Entities/Core/Users/ICurrentUser.Client.cs
+++ b/src/Disqord.Rest/Entities/Core/Users/ICurrentUser.Client.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace Disqord
+{
+    public partial interface ICurrentUser : IUser
+    {
+        Task ModifyAsync(Action<ModifyCurrentUserProperties> action, RestRequestOptions options = null);
+    }
+}

--- a/src/Disqord.Rest/Entities/Core/Users/ICurrentUser.cs
+++ b/src/Disqord.Rest/Entities/Core/Users/ICurrentUser.cs
@@ -1,9 +1,6 @@
-﻿using System;
-using System.Threading.Tasks;
-
-namespace Disqord
+﻿namespace Disqord
 {
-    public interface ICurrentUser : IUser
+    public partial interface ICurrentUser : IUser
     {
         string Locale { get; }
 
@@ -12,7 +9,5 @@ namespace Disqord
         string Email { get; }
 
         bool HasMfaEnabled { get; }
-
-        Task ModifyAsync(Action<ModifyCurrentUserProperties> action, RestRequestOptions options = null);
     }
 }

--- a/src/Disqord.Rest/Entities/Core/Users/IMember.Client.cs
+++ b/src/Disqord.Rest/Entities/Core/Users/IMember.Client.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace Disqord
+{
+    public partial interface IMember : IUser
+    {
+        Task ModifyAsync(Action<ModifyMemberProperties> action, RestRequestOptions options = null);
+
+        Task GrantRoleAsync(Snowflake roleId, RestRequestOptions options = null);
+
+        Task RevokeRoleAsync(Snowflake roleId, RestRequestOptions options = null);
+
+        Task KickAsync(RestRequestOptions options = null);
+
+        Task BanAsync(string reason = null, int? messageDeleteDays = null, RestRequestOptions options = null);
+
+        Task UnbanAsync(RestRequestOptions options = null);
+    }
+}

--- a/src/Disqord.Rest/Entities/Core/Users/IMember.cs
+++ b/src/Disqord.Rest/Entities/Core/Users/IMember.cs
@@ -1,10 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Threading.Tasks;
 
 namespace Disqord
 {
-    public interface IMember : IUser
+    public partial interface IMember : IUser
     {
         string Nick { get; }
 
@@ -21,17 +20,5 @@ namespace Disqord
         DateTimeOffset? BoostedAt { get; }
 
         bool IsBoosting { get; }
-
-        Task ModifyAsync(Action<ModifyMemberProperties> action, RestRequestOptions options = null);
-
-        Task KickAsync(RestRequestOptions options = null);
-
-        Task BanAsync(string reason = null, int? messageDeleteDays = null, RestRequestOptions options = null);
-
-        Task UnbanAsync(RestRequestOptions options = null);
-
-        Task GrantRoleAsync(Snowflake roleId, RestRequestOptions options = null);
-
-        Task RevokeRoleAsync(Snowflake roleId, RestRequestOptions options = null);
     }
 }

--- a/src/Disqord.Rest/Entities/Core/Users/IMember.cs
+++ b/src/Disqord.Rest/Entities/Core/Users/IMember.cs
@@ -26,9 +26,7 @@ namespace Disqord
 
         Task KickAsync(RestRequestOptions options = null);
 
-        Task BanAsync(string reason = null, RestRequestOptions options = null);
-
-        Task BanAsync(int messageDeleteDays, string reason = null, RestRequestOptions options = null);
+        Task BanAsync(string reason = null, int? messageDeleteDays = null, RestRequestOptions options = null);
 
         Task UnbanAsync(RestRequestOptions options = null);
 

--- a/src/Disqord.Rest/Entities/Core/Users/IUser.Client.cs
+++ b/src/Disqord.Rest/Entities/Core/Users/IUser.Client.cs
@@ -1,0 +1,20 @@
+﻿using System.Threading.Tasks;
+using Disqord.Rest;
+
+namespace Disqord
+{
+    public partial interface IUser : IMessagable, IMentionable, ITaggable
+    {
+        Task CreateRelationshipAsync(RelationshipType? type = null, RestRequestOptions options = null);
+
+        Task DeleteRelationshipAsync(RestRequestOptions options = null);
+
+        Task SendFriendRequestAsync(RestRequestOptions options = null);
+
+        Task<RestUserProfile> GetProfileAsync(RestRequestOptions options = null);
+
+        Task SetNoteAsync(string note, RestRequestOptions options = null);
+
+        Task<RestDmChannel> CreateDmChannelAsync(RestRequestOptions options = null);
+    }
+}

--- a/src/Disqord.Rest/Entities/Core/Users/IUser.Client.cs
+++ b/src/Disqord.Rest/Entities/Core/Users/IUser.Client.cs
@@ -5,11 +5,11 @@ namespace Disqord
 {
     public partial interface IUser : IMessagable, IMentionable, ITaggable
     {
-        Task CreateRelationshipAsync(RelationshipType? type = null, RestRequestOptions options = null);
+        Task AddFriendAsync(RestRequestOptions options = null);
 
-        Task DeleteRelationshipAsync(RestRequestOptions options = null);
+        Task BlockAsync(RestRequestOptions options = null);
 
-        Task SendFriendRequestAsync(RestRequestOptions options = null);
+        Task UnfriendOrUnblockAsync(RestRequestOptions options = null);
 
         Task<RestUserProfile> GetProfileAsync(RestRequestOptions options = null);
 

--- a/src/Disqord.Rest/Entities/Core/Users/IUser.cs
+++ b/src/Disqord.Rest/Entities/Core/Users/IUser.cs
@@ -1,9 +1,6 @@
-﻿using System.Threading.Tasks;
-using Disqord.Rest;
-
-namespace Disqord
+﻿namespace Disqord
 {
-    public interface IUser : IMessagable, IMentionable, ITaggable
+    public partial interface IUser : IMessagable, IMentionable, ITaggable
     {
         string Name { get; }
 
@@ -14,11 +11,5 @@ namespace Disqord
         bool IsBot { get; }
 
         string GetAvatarUrl(ImageFormat? imageFormat = null, int size = 2048);
-
-        Task SetNoteAsync(string note, RestRequestOptions options = null);
-
-        //Task SendFriendRequestAsync(RestRequestOptions options = null);
-
-        Task<RestDmChannel> CreateDmChannelAsync(RestRequestOptions options = null);
     }
 }

--- a/src/Disqord.Rest/Entities/Rest/Guild/RestGuild.Client.cs
+++ b/src/Disqord.Rest/Entities/Rest/Guild/RestGuild.Client.cs
@@ -101,8 +101,8 @@ namespace Disqord.Rest
             return ban;
         }
 
-        public Task BanMemberAsync(Snowflake memberId, int? deleteMessageDays = null, string reason = null, RestRequestOptions options = null)
-            => Client.BanMemberAsync(Id, memberId, deleteMessageDays, reason, options);
+        public Task BanMemberAsync(Snowflake memberId, string reason = null, int? deleteMessageDays = null, RestRequestOptions options = null)
+            => Client.BanMemberAsync(Id, memberId, reason, deleteMessageDays, options);
 
         public Task UnbanMemberAsync(Snowflake userId, RestRequestOptions options = null)
             => Client.UnbanMemberAsync(Id, userId, options);

--- a/src/Disqord.Rest/Entities/Rest/Guild/RestRole.Client.cs
+++ b/src/Disqord.Rest/Entities/Rest/Guild/RestRole.Client.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace Disqord.Rest
+{
+    public sealed partial class RestRole : RestSnowflakeEntity, IRole
+    {
+        public async Task ModifyAsync(Action<ModifyRoleProperties> action, RestRequestOptions options = null)
+        {
+            var model = await Client.InternalModifyRoleAsync(GuildId, Id, action, options).ConfigureAwait(false);
+            Update(model);
+        }
+
+        public Task DeleteAsync(RestRequestOptions options = null)
+            => Client.DeleteRoleAsync(GuildId, Id, options);
+    }
+}

--- a/src/Disqord.Rest/Entities/Rest/Guild/RestRole.cs
+++ b/src/Disqord.Rest/Entities/Rest/Guild/RestRole.cs
@@ -1,10 +1,8 @@
-﻿using System;
-using System.Threading.Tasks;
-using Disqord.Models;
+﻿using Disqord.Models;
 
 namespace Disqord.Rest
 {
-    public sealed class RestRole : RestSnowflakeEntity, IRole
+    public sealed partial class RestRole : RestSnowflakeEntity, IRole
     {
         public string Name { get; private set; }
 
@@ -43,15 +41,6 @@ namespace Disqord.Rest
             IsManaged = model.Managed;
             IsMentionable = model.Mentionable;
         }
-
-        public async Task ModifyAsync(Action<ModifyRoleProperties> action, RestRequestOptions options = null)
-        {
-            var model = await Client.InternalModifyRoleAsync(GuildId, Id, action, options).ConfigureAwait(false);
-            Update(model);
-        }
-
-        public Task DeleteAsync(RestRequestOptions options = null)
-            => Client.DeleteRoleAsync(GuildId, Id, options);
 
         public override string ToString()
             => Name;

--- a/src/Disqord.Rest/Entities/Rest/Users/RestCurrentUser.Client.cs
+++ b/src/Disqord.Rest/Entities/Rest/Users/RestCurrentUser.Client.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace Disqord.Rest
+{
+    public sealed partial class RestCurrentUser : RestUser, ICurrentUser
+    {
+        public Task ModifyAsync(Action<ModifyCurrentUserProperties> action, RestRequestOptions options = null)
+            => Client.ModifyCurrentUserAsync(action, options);
+    }
+}

--- a/src/Disqord.Rest/Entities/Rest/Users/RestCurrentUser.cs
+++ b/src/Disqord.Rest/Entities/Rest/Users/RestCurrentUser.cs
@@ -1,10 +1,8 @@
-﻿using System;
-using System.Threading.Tasks;
-using Disqord.Models;
+﻿using Disqord.Models;
 
 namespace Disqord.Rest
 {
-    public sealed class RestCurrentUser : RestUser, ICurrentUser
+    public sealed partial class RestCurrentUser : RestUser, ICurrentUser
     {
         public string Locale { get; private set; }
 
@@ -35,8 +33,5 @@ namespace Disqord.Rest
 
             base.Update(model);
         }
-
-        public Task ModifyAsync(Action<ModifyCurrentUserProperties> action, RestRequestOptions options = null)
-            => Client.ModifyCurrentUserAsync(action, options);
     }
 }

--- a/src/Disqord.Rest/Entities/Rest/Users/RestMember.Client.cs
+++ b/src/Disqord.Rest/Entities/Rest/Users/RestMember.Client.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace Disqord.Rest
+{
+    public sealed partial class RestMember : RestUser, IMember
+    {
+        public Task ModifyAsync(Action<ModifyMemberProperties> action, RestRequestOptions options = null)
+            => Client.ModifyMemberAsync(GuildId, Id, action, options);
+
+        public Task GrantRoleAsync(Snowflake roleId, RestRequestOptions options = null)
+            => Client.GrantRoleAsync(GuildId, Id, roleId, options);
+
+        public Task RevokeRoleAsync(Snowflake roleId, RestRequestOptions options = null)
+            => Client.RevokeRoleAsync(GuildId, Id, roleId, options);
+
+        public Task KickAsync(RestRequestOptions options = null)
+            => Client.KickMemberAsync(GuildId, Id, options);
+
+        public Task BanAsync(string reason = null, int? messageDeleteDays = null, RestRequestOptions options = null)
+            => Client.BanMemberAsync(GuildId, Id, reason, messageDeleteDays, options);
+
+        public Task UnbanAsync(RestRequestOptions options = null)
+            => Client.UnbanMemberAsync(GuildId, Id, options);
+    }
+}

--- a/src/Disqord.Rest/Entities/Rest/Users/RestMember.cs
+++ b/src/Disqord.Rest/Entities/Rest/Users/RestMember.cs
@@ -57,11 +57,8 @@ namespace Disqord.Rest
         public Task KickAsync(RestRequestOptions options = null)
             => Client.KickMemberAsync(GuildId, Id, options);
 
-        public Task BanAsync(string reason = null, RestRequestOptions options = null)
-            => Client.BanMemberAsync(GuildId, Id, null, reason, options);
-
-        public Task BanAsync(int messageDeleteDays, string reason = null, RestRequestOptions options = null)
-            => Client.BanMemberAsync(GuildId, Id, messageDeleteDays, reason, options);
+        public Task BanAsync(string reason = null, int? messageDeleteDays = null, RestRequestOptions options = null)
+            => Client.BanMemberAsync(GuildId, Id, reason, messageDeleteDays, options);
 
         public Task UnbanAsync(RestRequestOptions options = null)
             => Client.UnbanMemberAsync(GuildId, Id, options);

--- a/src/Disqord.Rest/Entities/Rest/Users/RestMember.cs
+++ b/src/Disqord.Rest/Entities/Rest/Users/RestMember.cs
@@ -1,12 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Threading.Tasks;
 using Disqord.Models;
 
 namespace Disqord.Rest
 {
-    public sealed class RestMember : RestUser, IMember
+    public sealed partial class RestMember : RestUser, IMember
     {
         public string Nick { get; private set; }
 
@@ -50,23 +49,5 @@ namespace Disqord.Rest
 
             base.Update(model.User);
         }
-
-        public Task ModifyAsync(Action<ModifyMemberProperties> action, RestRequestOptions options = null)
-            => Client.ModifyMemberAsync(GuildId, Id, action, options);
-
-        public Task KickAsync(RestRequestOptions options = null)
-            => Client.KickMemberAsync(GuildId, Id, options);
-
-        public Task BanAsync(string reason = null, int? messageDeleteDays = null, RestRequestOptions options = null)
-            => Client.BanMemberAsync(GuildId, Id, reason, messageDeleteDays, options);
-
-        public Task UnbanAsync(RestRequestOptions options = null)
-            => Client.UnbanMemberAsync(GuildId, Id, options);
-
-        public Task GrantRoleAsync(Snowflake roleId, RestRequestOptions options = null)
-            => Client.GrantRoleAsync(GuildId, Id, roleId, options);
-
-        public Task RevokeRoleAsync(Snowflake roleId, RestRequestOptions options = null)
-            => Client.RevokeRoleAsync(GuildId, Id, roleId, options);
     }
 }

--- a/src/Disqord.Rest/Entities/Rest/Users/RestUser.Client.cs
+++ b/src/Disqord.Rest/Entities/Rest/Users/RestUser.Client.cs
@@ -1,0 +1,44 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Disqord.Rest
+{
+    public partial class RestUser : RestSnowflakeEntity, IUser
+    {
+        public Task CreateRelationshipAsync(RelationshipType? type = null, RestRequestOptions options = null)
+            => Client.CreateRelationshipAsync(Id, type, options);
+
+        public Task DeleteRelationshipAsync(RestRequestOptions options = null)
+            => Client.DeleteRelationshipAsync(Id, options);
+
+        public Task SendFriendRequestAsync(RestRequestOptions options = null)
+            => CreateRelationshipAsync(options: options);
+
+        public Task<RestUserProfile> GetProfileAsync(RestRequestOptions options = null)
+            => Client.GetUserProfileAsync(Id, options);
+
+        public Task SetNoteAsync(string note, RestRequestOptions options = null)
+            => Client.SetNoteAsync(Id, note, options);
+
+        public Task<RestDmChannel> CreateDmChannelAsync(RestRequestOptions options = null)
+            => Client.CreateDmChannelAsync(Id, options);
+
+        public async Task<RestUserMessage> SendMessageAsync(string content = null, bool textToSpeech = false, Embed embed = null, RestRequestOptions options = null)
+        {
+            var channel = await CreateDmChannelAsync(options).ConfigureAwait(false);
+            return await channel.SendMessageAsync(content, textToSpeech, embed, options).ConfigureAwait(false);
+        }
+
+        public async Task<RestUserMessage> SendMessageAsync(LocalAttachment attachment, string content = null, bool textToSpeech = false, Embed embed = null, RestRequestOptions options = null)
+        {
+            var channel = await CreateDmChannelAsync(options).ConfigureAwait(false);
+            return await channel.SendMessageAsync(attachment, content, textToSpeech, embed, options).ConfigureAwait(false);
+        }
+
+        public async Task<RestUserMessage> SendMessageAsync(IEnumerable<LocalAttachment> attachments, string content = null, bool textToSpeech = false, Embed embed = null, RestRequestOptions options = null)
+        {
+            var channel = await CreateDmChannelAsync(options).ConfigureAwait(false);
+            return await channel.SendMessageAsync(attachments, content, textToSpeech, embed, options).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/Disqord.Rest/Entities/Rest/Users/RestUser.Client.cs
+++ b/src/Disqord.Rest/Entities/Rest/Users/RestUser.Client.cs
@@ -5,14 +5,14 @@ namespace Disqord.Rest
 {
     public partial class RestUser : RestSnowflakeEntity, IUser
     {
-        public Task CreateRelationshipAsync(RelationshipType? type = null, RestRequestOptions options = null)
-            => Client.CreateRelationshipAsync(Id, type, options);
+        public Task AddFriendAsync(RestRequestOptions options = null)
+            => Client.CreateRelationshipAsync(Id, options: options);
 
-        public Task DeleteRelationshipAsync(RestRequestOptions options = null)
+        public Task BlockAsync(RestRequestOptions options = null)
+            => Client.CreateRelationshipAsync(Id, RelationshipType.Blocked, options);
+
+        public Task UnfriendOrUnblockAsync(RestRequestOptions options = null)
             => Client.DeleteRelationshipAsync(Id, options);
-
-        public Task SendFriendRequestAsync(RestRequestOptions options = null)
-            => CreateRelationshipAsync(options: options);
 
         public Task<RestUserProfile> GetProfileAsync(RestRequestOptions options = null)
             => Client.GetUserProfileAsync(Id, options);

--- a/src/Disqord.Rest/Entities/Rest/Users/RestUser.cs
+++ b/src/Disqord.Rest/Entities/Rest/Users/RestUser.cs
@@ -4,7 +4,7 @@ using Disqord.Models;
 
 namespace Disqord.Rest
 {
-    public class RestUser : RestSnowflakeEntity, IUser
+    public partial class RestUser : RestSnowflakeEntity, IUser
     {
         public string Name { get; private set; }
 
@@ -33,31 +33,7 @@ namespace Disqord.Rest
 
         public string GetAvatarUrl(ImageFormat? imageFormat = null, int size = 2048)
             => Discord.Internal.GetAvatarUrl(this);
-
-        public Task SetNoteAsync(string note, RestRequestOptions options = null)
-            => Client.SetNoteAsync(Id, note, options);
-
-        public Task<RestDmChannel> CreateDmChannelAsync(RestRequestOptions options = null)
-            => Client.CreateDmChannelAsync(Id, options);
-
-        public async Task<RestUserMessage> SendMessageAsync(string content = null, bool textToSpeech = false, Embed embed = null, RestRequestOptions options = null)
-        {
-            var channel = await CreateDmChannelAsync(options).ConfigureAwait(false);
-            return await channel.SendMessageAsync(content, textToSpeech, embed, options).ConfigureAwait(false);
-        }
-
-        public async Task<RestUserMessage> SendMessageAsync(LocalAttachment attachment, string content = null, bool textToSpeech = false, Embed embed = null, RestRequestOptions options = null)
-        {
-            var channel = await CreateDmChannelAsync(options).ConfigureAwait(false);
-            return await channel.SendMessageAsync(attachment, content, textToSpeech, embed, options).ConfigureAwait(false);
-        }
-
-        public async Task<RestUserMessage> SendMessageAsync(IEnumerable<LocalAttachment> attachments, string content = null, bool textToSpeech = false, Embed embed = null, RestRequestOptions options = null)
-        {
-            var channel = await CreateDmChannelAsync(options).ConfigureAwait(false);
-            return await channel.SendMessageAsync(attachments, content, textToSpeech, embed, options).ConfigureAwait(false);
-        }
-
+        
         public override string ToString()
             => Tag;
     }

--- a/src/Disqord/Client/DiscordClientBase.Rest.cs
+++ b/src/Disqord/Client/DiscordClientBase.Rest.cs
@@ -50,7 +50,7 @@ namespace Disqord
         public Task KickMemberAsync(Snowflake guildId, Snowflake memberId, RestRequestOptions options = null) => ((IRestDiscordClient) this.RestClient).KickMemberAsync(guildId, memberId, options);
         public Task<IReadOnlyList<RestBan>> GetBansAsync(Snowflake guildId, RestRequestOptions options = null) => ((IRestDiscordClient) this.RestClient).GetBansAsync(guildId, options);
         public Task<RestBan> GetBanAsync(Snowflake guildId, Snowflake userId, RestRequestOptions options = null) => ((IRestDiscordClient) this.RestClient).GetBanAsync(guildId, userId, options);
-        public Task BanMemberAsync(Snowflake guildId, Snowflake memberId, int? deleteMessageDays = null, string reason = null, RestRequestOptions options = null) => ((IRestDiscordClient) this.RestClient).BanMemberAsync(guildId, memberId, deleteMessageDays, reason, options);
+        public Task BanMemberAsync(Snowflake guildId, Snowflake memberId, string reason = null, int? deleteMessageDays = null, RestRequestOptions options = null) => ((IRestDiscordClient) this.RestClient).BanMemberAsync(guildId, memberId, reason, deleteMessageDays, options);
         public Task UnbanMemberAsync(Snowflake guildId, Snowflake userId, RestRequestOptions options = null) => ((IRestDiscordClient) this.RestClient).UnbanMemberAsync(guildId, userId, options);
         public Task<IReadOnlyList<RestRole>> GetRolesAsync(Snowflake guildId, RestRequestOptions options = null) => ((IRestDiscordClient) this.RestClient).GetRolesAsync(guildId, options);
         public Task<RestRole> CreateRoleAsync(Snowflake guildId, Action<CreateRoleProperties> action = null, RestRequestOptions options = null) => ((IRestDiscordClient) this.RestClient).CreateRoleAsync(guildId, action, options);

--- a/src/Disqord/Entities/Guild/CachedGuild.Client.cs
+++ b/src/Disqord/Entities/Guild/CachedGuild.Client.cs
@@ -70,8 +70,8 @@ namespace Disqord
         public Task<RestBan> GetBanAsync(Snowflake userId, RestRequestOptions options = null)
             => Client.GetBanAsync(Id, userId, options);
 
-        public Task BanMemberAsync(Snowflake memberId, int? deleteMessageDays = null, string reason = null, RestRequestOptions options = null)
-            => Client.BanMemberAsync(Id, memberId, deleteMessageDays, reason, options);
+        public Task BanMemberAsync(Snowflake memberId, string reason = null, int? deleteMessageDays = null, RestRequestOptions options = null)
+            => Client.BanMemberAsync(Id, memberId, reason, deleteMessageDays, options);
 
         public Task UnbanMemberAsync(Snowflake userId, RestRequestOptions options = null)
             => Client.UnbanMemberAsync(Id, userId, options);

--- a/src/Disqord/Entities/Guild/CachedRole.Client.cs
+++ b/src/Disqord/Entities/Guild/CachedRole.Client.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace Disqord
+{
+    public sealed partial class CachedRole : CachedSnowflakeEntity, IRole
+    {
+        public async Task ModifyAsync(Action<ModifyRoleProperties> action, RestRequestOptions options = null)
+        {
+            var model = await Client.RestClient.InternalModifyRoleAsync(Guild.Id, Id, action, options).ConfigureAwait(false);
+            Update(model);
+        }
+
+        public Task DeleteAsync(RestRequestOptions options = null)
+            => Client.DeleteRoleAsync(Guild.Id, Id, options);
+    }
+}

--- a/src/Disqord/Entities/Guild/CachedRole.cs
+++ b/src/Disqord/Entities/Guild/CachedRole.cs
@@ -1,12 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 using Disqord.Collections;
 using Disqord.Models;
 
 namespace Disqord
 {
-    public sealed class CachedRole : CachedSnowflakeEntity, IRole
+    public sealed partial class CachedRole : CachedSnowflakeEntity, IRole
     {
         public string Name { get; private set; }
 
@@ -50,12 +48,6 @@ namespace Disqord
 
         internal CachedRole Clone()
             => (CachedRole) MemberwiseClone();
-
-        public Task ModifyAsync(Action<ModifyRoleProperties> action, RestRequestOptions options = null)
-            => Client.ModifyRoleAsync(Guild.Id, Id, action, options);
-
-        public Task DeleteAsync(RestRequestOptions options = null)
-            => Client.DeleteRoleAsync(Guild.Id, Id, options);
 
         public override string ToString()
             => Name;

--- a/src/Disqord/Entities/Users/CachedCurrentUser.Client.cs
+++ b/src/Disqord/Entities/Users/CachedCurrentUser.Client.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace Disqord
+{
+    public sealed partial class CachedCurrentUser : CachedUser, ICurrentUser
+    {
+        public Task ModifyAsync(Action<ModifyCurrentUserProperties> action, RestRequestOptions options = null)
+            => Client.ModifyCurrentUserAsync(action, options);
+    }
+}

--- a/src/Disqord/Entities/Users/CachedCurrentUser.cs
+++ b/src/Disqord/Entities/Users/CachedCurrentUser.cs
@@ -2,13 +2,12 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Threading.Tasks;
 using Disqord.Models;
 using Qommon.Collections;
 
 namespace Disqord
 {
-    public sealed class CachedCurrentUser : CachedUser, ICurrentUser
+    public sealed partial class CachedCurrentUser : CachedUser, ICurrentUser
     {
         public override string Name => SharedUser.Name;
 
@@ -124,8 +123,5 @@ namespace Disqord
         {
             _notes.AddOrUpdate(id, note, func);
         }
-
-        public Task ModifyAsync(Action<ModifyCurrentUserProperties> action, RestRequestOptions options = null)
-            => Client.ModifyCurrentUserAsync(action, options);
     }
 }

--- a/src/Disqord/Entities/Users/CachedMember.Client.cs
+++ b/src/Disqord/Entities/Users/CachedMember.Client.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace Disqord
+{
+    public sealed partial class CachedMember : CachedUser, IMember
+    {
+        public Task ModifyAsync(Action<ModifyMemberProperties> action, RestRequestOptions options = null)
+            => Client.ModifyMemberAsync(Guild.Id, Id, action, options);
+
+        public Task GrantRoleAsync(Snowflake roleId, RestRequestOptions options = null)
+            => Client.GrantRoleAsync(Guild.Id, Id, roleId, options);
+
+        public Task RevokeRoleAsync(Snowflake roleId, RestRequestOptions options = null)
+            => Client.RevokeRoleAsync(Guild.Id, Id, roleId, options);
+
+        public Task KickAsync(RestRequestOptions options = null)
+            => Client.KickMemberAsync(Guild.Id, Id, options);
+
+        public Task BanAsync(string reason = null, int? messageDeleteDays = null, RestRequestOptions options = null)
+            => Client.BanMemberAsync(Guild.Id, Id, reason, messageDeleteDays, options);
+
+        public Task UnbanAsync(RestRequestOptions options = null)
+            => Client.UnbanMemberAsync(Guild.Id, Id, options);
+    }
+}

--- a/src/Disqord/Entities/Users/CachedMember.cs
+++ b/src/Disqord/Entities/Users/CachedMember.cs
@@ -217,11 +217,8 @@ namespace Disqord
         public Task KickAsync(RestRequestOptions options = null)
             => Client.KickMemberAsync(Guild.Id, Id, options);
 
-        public Task BanAsync(string reason = null, RestRequestOptions options = null)
-            => Client.BanMemberAsync(Guild.Id, Id, null, reason, options);
-
-        public Task BanAsync(int messageDeleteDays, string reason = null, RestRequestOptions options = null)
-            => Client.BanMemberAsync(Guild.Id, Id, messageDeleteDays, reason, options);
+        public Task BanAsync(string reason = null, int? messageDeleteDays = null, RestRequestOptions options = null)
+            => Client.BanMemberAsync(Guild.Id, Id, reason, messageDeleteDays, options);
 
         public Task UnbanAsync(RestRequestOptions options = null)
             => Client.UnbanMemberAsync(Guild.Id, Id, options);

--- a/src/Disqord/Entities/Users/CachedMember.cs
+++ b/src/Disqord/Entities/Users/CachedMember.cs
@@ -2,7 +2,6 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
 using Disqord.Logging;
 using Disqord.Models;
 using Disqord.Models.Dispatches;
@@ -10,7 +9,7 @@ using Qommon.Collections;
 
 namespace Disqord
 {
-    public sealed class CachedMember : CachedUser, IMember
+    public sealed partial class CachedMember : CachedUser, IMember
     {
         public override string Name => SharedUser.Name;
 
@@ -210,23 +209,5 @@ namespace Disqord
 
         public ChannelPermissions GetPermissionsFor(IGuildChannel channel)
             => Discord.Permissions.CalculatePermissions(Guild, channel, this, Roles.Values);
-
-        public Task ModifyAsync(Action<ModifyMemberProperties> action, RestRequestOptions options = null)
-            => Client.ModifyMemberAsync(Guild.Id, Id, action, options);
-
-        public Task KickAsync(RestRequestOptions options = null)
-            => Client.KickMemberAsync(Guild.Id, Id, options);
-
-        public Task BanAsync(string reason = null, int? messageDeleteDays = null, RestRequestOptions options = null)
-            => Client.BanMemberAsync(Guild.Id, Id, reason, messageDeleteDays, options);
-
-        public Task UnbanAsync(RestRequestOptions options = null)
-            => Client.UnbanMemberAsync(Guild.Id, Id, options);
-
-        public Task GrantRoleAsync(Snowflake roleId, RestRequestOptions options = null)
-            => Client.GrantRoleAsync(Guild.Id, Id, roleId, options);
-
-        public Task RevokeRoleAsync(Snowflake roleId, RestRequestOptions options = null)
-            => Client.RevokeRoleAsync(Guild.Id, Id, roleId, options);
     }
 }

--- a/src/Disqord/Entities/Users/CachedUser.Client.cs
+++ b/src/Disqord/Entities/Users/CachedUser.Client.cs
@@ -6,14 +6,14 @@ namespace Disqord
 {
     public abstract partial class CachedUser : CachedSnowflakeEntity, IUser
     {
-        public Task CreateRelationshipAsync(RelationshipType? type = null, RestRequestOptions options = null)
-            => Client.CreateRelationshipAsync(Id, type, options);
+        public Task AddFriendAsync(RestRequestOptions options = null)
+            => Client.CreateRelationshipAsync(Id, options: options);
 
-        public Task DeleteRelationshipAsync(RestRequestOptions options = null)
+        public Task BlockAsync(RestRequestOptions options = null)
+            => Client.CreateRelationshipAsync(Id, RelationshipType.Blocked, options);
+
+        public Task UnfriendOrUnblockAsync(RestRequestOptions options = null)
             => Client.DeleteRelationshipAsync(Id, options);
-
-        public Task SendFriendRequestAsync(RestRequestOptions options = null)
-            => CreateRelationshipAsync(options: options);
 
         public Task<RestUserProfile> GetProfileAsync(RestRequestOptions options = null)
             => Client.GetUserProfileAsync(Id, options);

--- a/src/Disqord/Entities/Users/CachedUser.Client.cs
+++ b/src/Disqord/Entities/Users/CachedUser.Client.cs
@@ -1,0 +1,45 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Disqord.Rest;
+
+namespace Disqord
+{
+    public abstract partial class CachedUser : CachedSnowflakeEntity, IUser
+    {
+        public Task CreateRelationshipAsync(RelationshipType? type = null, RestRequestOptions options = null)
+            => Client.CreateRelationshipAsync(Id, type, options);
+
+        public Task DeleteRelationshipAsync(RestRequestOptions options = null)
+            => Client.DeleteRelationshipAsync(Id, options);
+
+        public Task SendFriendRequestAsync(RestRequestOptions options = null)
+            => CreateRelationshipAsync(options: options);
+
+        public Task<RestUserProfile> GetProfileAsync(RestRequestOptions options = null)
+            => Client.GetUserProfileAsync(Id, options);
+
+        public Task SetNoteAsync(string note, RestRequestOptions options = null)
+            => Client.SetNoteAsync(Id, note, options);
+
+        public Task<RestDmChannel> CreateDmChannelAsync(RestRequestOptions options = null)
+            => Client.CreateDmChannelAsync(Id, options);
+
+        public async Task<RestUserMessage> SendMessageAsync(string content = null, bool textToSpeech = false, Embed embed = null, RestRequestOptions options = null)
+        {
+            var channel = await CreateDmChannelAsync(options).ConfigureAwait(false);
+            return await channel.SendMessageAsync(content, textToSpeech, embed, options).ConfigureAwait(false);
+        }
+
+        public async Task<RestUserMessage> SendMessageAsync(LocalAttachment attachment, string content = null, bool textToSpeech = false, Embed embed = null, RestRequestOptions options = null)
+        {
+            var channel = await CreateDmChannelAsync(options).ConfigureAwait(false);
+            return await channel.SendMessageAsync(attachment, content, textToSpeech, embed, options).ConfigureAwait(false);
+        }
+
+        public async Task<RestUserMessage> SendMessageAsync(IEnumerable<LocalAttachment> attachments, string content = null, bool textToSpeech = false, Embed embed = null, RestRequestOptions options = null)
+        {
+            var channel = await CreateDmChannelAsync(options).ConfigureAwait(false);
+            return await channel.SendMessageAsync(attachments, content, textToSpeech, embed, options).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/Disqord/Entities/Users/CachedUser.cs
+++ b/src/Disqord/Entities/Users/CachedUser.cs
@@ -1,14 +1,11 @@
 ﻿using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
 using Disqord.Models;
-using Disqord.Rest;
 using PresenceUpdateDispatch = Disqord.Models.Dispatches.PresenceUpdateModel;
 
 namespace Disqord
 {
-    public abstract class CachedUser : CachedSnowflakeEntity, IUser
+    public abstract partial class CachedUser : CachedSnowflakeEntity, IUser
     {
         public virtual string Name { get; protected set; }
 
@@ -88,36 +85,6 @@ namespace Disqord
             => AvatarHash != null
                 ? Discord.GetUserAvatarUrl(Id, AvatarHash, imageFormat, size)
                 : Discord.GetDefaultUserAvatarUrl(Discriminator);
-
-        public Task SetNoteAsync(string note, RestRequestOptions options = null)
-            => Client.SetNoteAsync(Id, note, options);
-
-        public async Task<IDmChannel> GetOrCreateDMChannelAsync(RestRequestOptions options = null)
-        {
-            var channel = Client.DmChannels.Values.FirstOrDefault(x => x.Recipient.Id == Id);
-            return channel ?? (IDmChannel) await Client.CreateDmChannelAsync(Id, options).ConfigureAwait(false);
-        }
-
-        public Task<RestDmChannel> CreateDmChannelAsync(RestRequestOptions options = null)
-            => Client.CreateDmChannelAsync(Id, options);
-
-        public async Task<RestUserMessage> SendMessageAsync(string content = null, bool isTts = false, Embed embed = null, RestRequestOptions options = null)
-        {
-            var channel = await GetOrCreateDMChannelAsync(options).ConfigureAwait(false);
-            return await channel.SendMessageAsync(content, isTts, embed, options).ConfigureAwait(false);
-        }
-
-        public async Task<RestUserMessage> SendMessageAsync(LocalAttachment attachment, string content = null, bool isTts = false, Embed embed = null, RestRequestOptions options = null)
-        {
-            var channel = await GetOrCreateDMChannelAsync(options).ConfigureAwait(false);
-            return await channel.SendMessageAsync(attachment, content, isTts, embed, options).ConfigureAwait(false);
-        }
-
-        public async Task<RestUserMessage> SendMessageAsync(IEnumerable<LocalAttachment> attachments, string content = null, bool isTts = false, Embed embed = null, RestRequestOptions options = null)
-        {
-            var channel = await GetOrCreateDMChannelAsync(options).ConfigureAwait(false);
-            return await channel.SendMessageAsync(attachments, content, isTts, embed, options).ConfigureAwait(false);
-        }
 
         public override string ToString()
             => Tag;


### PR DESCRIPTION
This PR....actually does what I wanted it to. It also switches the order of the parameters on BanMemberAsync (and all methods which call it), swapping the amount of days of messages to delete with the reason, to reduce redundant method overloads. Capiche?