### PR TITLE
clean up

### DIFF
--- a/src/Disqord.Core/Optional.cs
+++ b/src/Disqord.Core/Optional.cs
@@ -57,7 +57,7 @@ namespace Disqord
         ///     The value of this <see cref="Optional{T}"/> or the default value of <typeparamref name="T"/>.
         /// </returns>
         public T GetValueOrDefault()
-            => HasValue ? _value : default;
+            => _value;
 
         /// <summary>
         ///     Returns a hash code for this <see cref="Optional{T}"/>.
@@ -85,15 +85,7 @@ namespace Disqord
         ///     The <see cref="bool"/> value reresenting whether the comparison succeeded.
         /// </returns>
         public override bool Equals(object obj)
-        {
-            if (obj is T value)
-                return Equals(value);
-
-            if (obj is Optional<T> optional)
-                return Equals(optional);
-
-            return false;
-        }
+            => obj is T value && Equals(value) || obj is Optional<T> optional && Equals(optional);
 
         /// <summary>
         ///     Checks whether this <see cref="Value"/> is equal to the specified <typeparamref name="T"/> value.

--- a/src/Disqord.Core/Snowflake.cs
+++ b/src/Disqord.Core/Snowflake.cs
@@ -80,17 +80,5 @@ namespace Disqord
 
         public static implicit operator DateTimeOffset(Snowflake value)
             => value.CreatedAt;
-
-        public static bool operator ==(Snowflake left, ulong right)
-            => left.Equals(right);
-
-        public static bool operator !=(Snowflake left, ulong right)
-            => !left.Equals(right);
-
-        public static bool operator >(Snowflake left, ulong right)
-            => left.RawValue > right;
-
-        public static bool operator <(Snowflake left, ulong right)
-            => left.RawValue < right;
     }
 }

--- a/src/Disqord.Rest/Entities/Local/LocalCustomEmoji.cs
+++ b/src/Disqord.Rest/Entities/Local/LocalCustomEmoji.cs
@@ -31,15 +31,13 @@
             => obj is IEmoji emoji && Equals(emoji);
 
         public bool Equals(IEmoji other)
-        {
-            if (other == null)
-                return false;
+            => !(other is ICustomEmoji) && Name == other.Name;
 
-            if (other is ICustomEmoji)
-                return false;
+        public static bool operator ==(LocalCustomEmoji left, LocalCustomEmoji right)
+            => left.Name == right.Name;
 
-            return Name.Equals(other.Name);
-        }
+        public static bool operator !=(LocalCustomEmoji left, LocalCustomEmoji right)
+            => left.Name == right.Name;
 
         public override string ToString()
             => MessageFormat;

--- a/src/Disqord.Rest/Entities/Rest/Emoji/RestGuildEmoji.cs
+++ b/src/Disqord.Rest/Entities/Rest/Emoji/RestGuildEmoji.cs
@@ -49,15 +49,13 @@ namespace Disqord.Rest
             => Discord.GetCustomEmojiUrl(Id, IsAnimated, size);
 
         public bool Equals(IEmoji other)
-        {
-            if (other == null)
-                return false;
+            => other is ICustomEmoji emoji && Id == emoji.Id;
 
-            if (!(other is ICustomEmoji customEmoji))
-                return false;
+        public static bool operator ==(RestGuildEmoji left, RestGuildEmoji right)
+            => left.Id == right.Id;
 
-            return Id.Equals(customEmoji.Id);
-        }
+        public static bool operator !=(RestGuildEmoji left, RestGuildEmoji right)
+            => left.Id != right.Id;
 
         public override string ToString()
             => MessageFormat;

--- a/src/Disqord.Rest/Entities/Shared/Emoji/CustomEmoji.cs
+++ b/src/Disqord.Rest/Entities/Shared/Emoji/CustomEmoji.cs
@@ -21,26 +21,16 @@
             => Discord.GetCustomEmojiUrl(Id, IsAnimated, size);
 
         public bool Equals(IEmoji other)
-        {
-            if (other == null)
-                return false;
-
-            if (!(other is ICustomEmoji customEmoji))
-                return false;
-
-            return Id.Equals(customEmoji.Id);
-        }
+            => other is ICustomEmoji emoji && Id == emoji.Id;
 
         public override bool Equals(object obj)
-        {
-            if (obj == null)
-                return false;
+            => obj is ICustomEmoji emoji && Id == emoji.Id;
 
-            if (!(obj is ICustomEmoji emoji))
-                return false;
+        public static bool operator ==(CustomEmoji left, CustomEmoji right)
+            => left.Id == right.Id;
 
-            return Equals(emoji);
-        }
+        public static bool operator !=(CustomEmoji left, CustomEmoji right)
+            => left.Id != right.Id;
 
         public override int GetHashCode()
             => Id.GetHashCode();

--- a/src/Disqord/Entities/Emoji/CachedGuildEmoji.cs
+++ b/src/Disqord/Entities/Emoji/CachedGuildEmoji.cs
@@ -47,15 +47,13 @@ namespace Disqord
             => Discord.GetCustomEmojiUrl(Id, IsAnimated, size);
 
         public bool Equals(IEmoji other)
-        {
-            if (other == null)
-                return false;
+            => other is ICustomEmoji emoji && Id == emoji.Id;
 
-            if (!(other is ICustomEmoji customEmoji))
-                return false;
+        public static bool operator ==(CachedGuildEmoji left, CachedGuildEmoji right)
+            => left.Id == right.Id;
 
-            return Id.Equals(customEmoji.Id);
-        }
+        public static bool operator !=(CachedGuildEmoji left, CachedGuildEmoji right)
+            => left.Id != right.Id;
 
         public Task DeleteAsync(RestRequestOptions options = null)
             => Client.DeleteGuildEmojiAsync(Guild.Id, Id, options);


### PR DESCRIPTION
On ` src/Disqord.Core/Optional.cs`
-> Improved GetValueOrDefault by removing redundant ternary.
-> Clean up on Equals and consistent with Equals implementation in other types

On `src/Disqord.Core/Snowflake.cs`
-> Removed unnecessary operators, Snowflake is already implicily convertible to ulong by returning its RawValue property, so the implicit conversion doesn't really have any overhead and it's very likely to be inlined by the jitter anyways.

On Emoji classes
-> Added `==` and `!=` operators. Also small clean up on equals.