### PR TITLE
Add support for escaping spoiler | and quote > characters in Markdown.

### DIFF
--- a/src/Disqord.Rest/Utilities/Markdown.cs
+++ b/src/Disqord.Rest/Utilities/Markdown.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text;
 using Qommon.Collections;
@@ -246,6 +246,49 @@ namespace Disqord
                 // special case for > quote character as to not break mentions
                 if (character == '>' && (i == 0 || text[i-1] == '\n'))
                     builder.Append('\\');
+
+                // special case for _ underline/italics as to not break custom emoji with an underline in the name
+                if (character == '_')
+                {
+                    if (i == 0)
+                    {
+                        builder.Append('\\');
+                    }
+                    else
+                    {
+                        int beginning = -1, end = int.MaxValue;
+                        // validate to the possible beginning of the emoji <
+                        for (var j = i - 1; j >= 0; j--)
+                        {
+                            var previousCharacter = text[j];
+                            if (previousCharacter == '<' && i < text.Length)
+                            {
+                                // we found the possible beginning of the emoji
+                                // now, try to find the end of the emoji >
+                                for (var k = i + 1; k < text.Length; k++)
+                                {
+                                    var nextCharacter = text[k];
+                                    if (nextCharacter == '>')
+                                    {
+                                        // we found the possible end of the emoji
+                                        end = k;
+                                        break;
+                                    }
+                                }
+
+                                beginning = j;
+                                break;
+                            }
+                        }
+
+                        if (beginning == -1 || end == int.MaxValue ||
+                            !LocalCustomEmoji.TryParse(text.Slice(beginning, end - beginning).ToString(), out _))
+                        {
+                            builder.Append('\\');
+                        }
+                            
+                    }
+                }
 
                 builder.Append(character);
             }

--- a/src/Disqord.Rest/Utilities/Markdown.cs
+++ b/src/Disqord.Rest/Utilities/Markdown.cs
@@ -10,13 +10,15 @@ namespace Disqord
         /// <summary>
         ///     The set containing the escaped markdown characters.
         /// </summary>
-        public static readonly ReadOnlySet<char> EscapedCharacters = new ReadOnlySet<char>(new HashSet<char>(5)
+        public static readonly ReadOnlySet<char> EscapedCharacters = new ReadOnlySet<char>(new HashSet<char>(7)
         {
             '\\',
             '*',
             '`',
             '_',
-            '~'
+            '~',
+            '|',
+            '>'
         });
 
         private const int STACK_TEXT_LENGTH = 2000;

--- a/src/Disqord.Rest/Utilities/Markdown.cs
+++ b/src/Disqord.Rest/Utilities/Markdown.cs
@@ -10,15 +10,14 @@ namespace Disqord
         /// <summary>
         ///     The set containing the escaped markdown characters.
         /// </summary>
-        public static readonly ReadOnlySet<char> EscapedCharacters = new ReadOnlySet<char>(new HashSet<char>(7)
+        public static readonly ReadOnlySet<char> EscapedCharacters = new ReadOnlySet<char>(new HashSet<char>(6)
         {
             '\\',
             '*',
             '`',
             '_',
             '~',
-            '|',
-            '>'
+            '|'
         });
 
         private const int STACK_TEXT_LENGTH = 2000;
@@ -242,6 +241,10 @@ namespace Disqord
             {
                 var character = text[i];
                 if (EscapedCharacters.Contains(character))
+                    builder.Append('\\');
+
+                // special case for > quote character as to not break mentions
+                if (character == '>' && (i == 0 || text[i-1] == '\n'))
                     builder.Append('\\');
 
                 builder.Append(character);

--- a/src/Disqord.Rest/Utilities/Markdown.cs
+++ b/src/Disqord.Rest/Utilities/Markdown.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Text;
 using Qommon.Collections;
@@ -10,14 +10,15 @@ namespace Disqord
         /// <summary>
         ///     The set containing the escaped markdown characters.
         /// </summary>
-        public static readonly ReadOnlySet<char> EscapedCharacters = new ReadOnlySet<char>(new HashSet<char>(6)
+        public static readonly ReadOnlySet<char> EscapedCharacters = new ReadOnlySet<char>(new HashSet<char>(7)
         {
             '\\',
             '*',
             '`',
-            '_',
+            '_', // except in custom emoji
             '~',
-            '|'
+            '|',
+            '>' // except in mentions
         });
 
         private const int STACK_TEXT_LENGTH = 2000;
@@ -240,7 +241,7 @@ namespace Disqord
             for (var i = 0; i < text.Length; i++)
             {
                 var character = text[i];
-                if (EscapedCharacters.Contains(character))
+                if (EscapedCharacters.Contains(character) && character != '>' && character != '_')
                     builder.Append('\\');
 
                 // special case for > quote character as to not break mentions


### PR DESCRIPTION
This adds additional characters to EscapedCharacters which is used with `Markdown.Escape()`.