### PR TITLE
Fixing NRE when bot is kicked from guild

### DIFF
--- a/src/Disqord/Client/Gateway/State/Events/GuildMemberRemove.cs
+++ b/src/Disqord/Client/Gateway/State/Events/GuildMemberRemove.cs
@@ -11,6 +11,10 @@ namespace Disqord
         {
             var model = payload.D.ToType<GuildMemberRemoveModel>();
             var guild = GetGuild(model.GuildId);
+
+            if (guild == null)
+                return Task.CompletedTask;
+
             var user = guild.TryRemoveMember(model.User.Id, out var member)
                 ? (CachedUser) member
                 : new CachedUnknownUser(_client, model.User);


### PR DESCRIPTION
There's an edge case where if the bot is kicked from a guild, GUILD_DELETE event may come before GUILD_MEMBER_REMOVE, which causes the guild to be null when member removal is being handled and throw a NullReferenceException.

This fix is what I considere the most appropiated since it's already "obvious" that the current user is "leaving" the guild so raising MemberLeft on this edge case is redundant.