### PR TITLE
Removed deprecated guild property: region

### DIFF
--- a/src/Disqord.Core/Entities/Core/AuditLogs/Guild/Data/IGuildAuditLogChanges.cs
+++ b/src/Disqord.Core/Entities/Core/AuditLogs/Guild/Data/IGuildAuditLogChanges.cs
@@ -20,8 +20,6 @@ namespace Disqord.AuditLogs
 
         AuditLogChange<Optional<IUser>> Owner { get; }
 
-        AuditLogChange<string> VoiceRegion { get; }
-
         AuditLogChange<CultureInfo> PreferredLocale { get; }
 
         AuditLogChange<Snowflake?> AfkChannelId { get; }

--- a/src/Disqord.Core/Entities/Core/Guild/IGuild.cs
+++ b/src/Disqord.Core/Entities/Core/Guild/IGuild.cs
@@ -31,11 +31,6 @@ namespace Disqord
         Snowflake OwnerId { get; }
 
         /// <summary>
-        ///     Gets the voice region of this guild.
-        /// </summary>
-        string VoiceRegion { get; }
-
-        /// <summary>
         ///     Gets the AFK channel ID of this guild.
         /// </summary>
         Snowflake? AfkChannelId { get; }
@@ -122,7 +117,7 @@ namespace Disqord
         int? MaxMemberCount { get; }
 
         /// <summary>
-        ///     Getsthe vanity URL code of this guild.
+        ///     Gets the vanity URL code of this guild.
         /// </summary>
         string VanityUrlCode { get; }
 

--- a/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Guild/Data/TransientGuildAuditLogChanges.cs
+++ b/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Guild/Data/TransientGuildAuditLogChanges.cs
@@ -23,8 +23,6 @@ namespace Disqord.AuditLogs
 
         public AuditLogChange<Optional<IUser>> Owner { get; }
 
-        public AuditLogChange<string> VoiceRegion { get; }
-
         public AuditLogChange<CultureInfo> PreferredLocale { get; }
 
         public AuditLogChange<Snowflake?> AfkChannelId { get; }
@@ -104,11 +102,6 @@ namespace Disqord.AuditLogs
                             newOwner = new TransientUser(client, newOwnerModel);
 
                         Owner = new AuditLogChange<Optional<IUser>>(Optional.FromNullable(oldOwner), Optional.FromNullable(newOwner));
-                        break;
-                    }
-                    case "region":
-                    {
-                        VoiceRegion = AuditLogChange<string>.Convert(change);
                         break;
                     }
                     case "preferred_locale":

--- a/src/Disqord.Core/Entities/Shared/Transient/Guild/TransientGuild.cs
+++ b/src/Disqord.Core/Entities/Shared/Transient/Guild/TransientGuild.cs
@@ -20,8 +20,6 @@ namespace Disqord
 
         public Snowflake OwnerId => Model.OwnerId;
 
-        public string VoiceRegion => Model.Region;
-
         public Snowflake? AfkChannelId => Model.AfkChannelId;
 
         public TimeSpan AfkTimeout => TimeSpan.FromSeconds(Model.AfkTimeout);

--- a/src/Disqord.Core/Models/GuildJsonModel.cs
+++ b/src/Disqord.Core/Models/GuildJsonModel.cs
@@ -32,9 +32,6 @@ namespace Disqord.Models
         [JsonProperty("permissions")]
         public Optional<ulong> Permissions;
 
-        [JsonProperty("region")]
-        public string Region;
-
         [JsonProperty("afk_channel_id")]
         public Snowflake? AfkChannelId;
 

--- a/src/Disqord.Gateway/Entities/Cached/CachedGuild.cs
+++ b/src/Disqord.Gateway/Entities/Cached/CachedGuild.cs
@@ -21,8 +21,6 @@ namespace Disqord.Gateway
 
         public Snowflake OwnerId { get; private set; }
 
-        public string VoiceRegion { get; private set; }
-
         public Snowflake? AfkChannelId { get; private set; }
 
         public TimeSpan AfkTimeout { get; private set; }
@@ -170,7 +168,6 @@ namespace Disqord.Gateway
                 DiscoverySplashHash = model.DiscoverySplash.Value;
 
             OwnerId = model.OwnerId;
-            VoiceRegion = model.Region;
             AfkChannelId = model.AfkChannelId;
             AfkTimeout = TimeSpan.FromSeconds(model.AfkTimeout);
 

--- a/src/Disqord.Rest.Api/Content/Json/CreateGuildJsonRestRequestContent.cs
+++ b/src/Disqord.Rest.Api/Content/Json/CreateGuildJsonRestRequestContent.cs
@@ -9,9 +9,6 @@ namespace Disqord.Rest.Api
         [JsonProperty("name")]
         public string Name;
 
-        [JsonProperty("region")]
-        public Optional<string> Region;
-
         [JsonProperty("icon")]
         public Optional<Stream> Icon;
 

--- a/src/Disqord.Rest.Api/Content/Json/ModifyGuildJsonRestRequestContent.cs
+++ b/src/Disqord.Rest.Api/Content/Json/ModifyGuildJsonRestRequestContent.cs
@@ -8,9 +8,6 @@ namespace Disqord.Rest.Api
         [JsonProperty("name")]
         public Optional<string> Name;
 
-        [JsonProperty("region")]
-        public Optional<string> Region;
-
         [JsonProperty("verification_level")]
         public Optional<GuildVerificationLevel> VerificationLevel;
 

--- a/src/Disqord.Rest/ActionProperties/Modify/ModifyGuildActionProperties.cs
+++ b/src/Disqord.Rest/ActionProperties/Modify/ModifyGuildActionProperties.cs
@@ -8,8 +8,6 @@ namespace Disqord
     {
         public Optional<string> Name { internal get; set; }
 
-        public Optional<string> VoiceRegionId { internal get; set; }
-
         public Optional<GuildVerificationLevel> VerificationLevel { internal get; set; }
 
         public Optional<GuildNotificationLevel> NotificationLevel { internal get; set; }

--- a/src/Disqord.Rest/Extensions/RestClientExtensions.Guild.cs
+++ b/src/Disqord.Rest/Extensions/RestClientExtensions.Guild.cs
@@ -37,7 +37,6 @@ namespace Disqord.Rest
             var content = new ModifyGuildJsonRestRequestContent
             {
                 Name = properties.Name,
-                Region = properties.VoiceRegionId,
                 VerificationLevel = properties.VerificationLevel,
                 DefaultMessageNotifications = properties.NotificationLevel,
                 ExplicitContentFilter = properties.ContentFilterLevel,


### PR DESCRIPTION
## Description

- Removed deprecated `region` property from guild.
- Fixed xml docs typo.

## Checklist

- [x] I discussed this PR with the maintainer(s) prior to opening it.
- [x] I read the [contributing guidelines](./.github/CONTRIBUTING.md).
- [x] I tested the changes in this PR.
