### PR TITLE
[ci skip] Fix LocalSelectionComponentOption giving wrong message with…

### DIFF
--- a/src/Disqord.Core/Entities/Local/Message/Components/Selection/LocalSelectionComponentOption.cs
+++ b/src/Disqord.Core/Entities/Local/Message/Components/Selection/LocalSelectionComponentOption.cs
@@ -42,7 +42,7 @@ namespace Disqord
             set
             {
                 if (value != null && value.Length > MaxDescriptionLength)
-                    throw new ArgumentOutOfRangeException(nameof(value), $"The selection option's value must not be longer than {MaxDescriptionLength} characters.");
+                    throw new ArgumentOutOfRangeException(nameof(value), $"The selection option's description must not be longer than {MaxDescriptionLength} characters.");
 
                 _description = value;
             }


### PR DESCRIPTION


## Description

I changed the exception message of LocalSelectionComponentOption for option descriptions.

## Checklist

[//]: # "Put an x in [ ] to check the checkbox, e.g. [x]"

- [x] I discussed this PR with the maintainer(s) prior to opening it.
- [ ] I read the [contributing guidelines](./.github/CONTRIBUTING.md).
- [ ] I tested the changes in this PR.
