### PR TITLE
Update max length of select option label and description

### DIFF
--- a/src/Disqord.Core/Entities/Local/Message/Components/Selection/LocalSelectionComponentOption.cs
+++ b/src/Disqord.Core/Entities/Local/Message/Components/Selection/LocalSelectionComponentOption.cs
@@ -4,11 +4,11 @@ namespace Disqord
 {
     public class LocalSelectionComponentOption : ILocalConstruct
     {
-        public const int MaxLabelLength = 25;
+        public const int MaxLabelLength = 100;
 
         public const int MaxValueLength = 100;
 
-        public const int MaxDescriptionLength = 50;
+        public const int MaxDescriptionLength = 100;
 
         public string Label
         {


### PR DESCRIPTION
## Description

- Updated max length of select option label to 100.
- Updated max length of select option description to 100.

## Checklist

- [x] I discussed this PR with the maintainer(s) prior to opening it.
- [x] I read the [contributing guidelines](./.github/CONTRIBUTING.md).
- [x] I tested the changes in this PR.
