### PR TITLE
Changes on AsynchronousEvent`1.cs and OptionalExtensions.cs

### DIFF
--- a/src/Disqord.Core/OptionalExtensions.cs
+++ b/src/Disqord.Core/OptionalExtensions.cs
@@ -9,7 +9,7 @@ namespace Disqord
     {
         public static T? GetValueOrNullable<T>(this Optional<T> optional)
             where T : struct
-            => optional.HasValue ? optional.Value : new T?();
+            => optional.HasValue ? optional.Value : default(T?);
 
         public static T GetValueOrDefault<T>(this Optional<T> optional)
             => optional.HasValue ? optional.Value : default;

--- a/src/Disqord.Core/OptionalExtensions.cs
+++ b/src/Disqord.Core/OptionalExtensions.cs
@@ -9,7 +9,7 @@ namespace Disqord
     {
         public static T? GetValueOrNullable<T>(this Optional<T> optional)
             where T : struct
-            => optional.HasValue ? optional.Value : default(T?);
+            => optional.HasValue ? optional.Value : new T?();
 
         public static T GetValueOrDefault<T>(this Optional<T> optional)
             => optional.HasValue ? optional.Value : default;


### PR DESCRIPTION
## Description

Changed `ImmutableHashSet<>` for `ImmutableStack` to keep event's order semantics.

## Checklist

[//]: # "Put an x in [ ] to check the checkbox, e.g. [x]"

- [X] I discussed this PR with the maintainer(s) prior to opening it.
- [X] I read the [contributing guidelines](./.github/CONTRIBUTING.md).
- [X] I tested the changes in this PR.
