### PR TITLE
Added support for animated guild banners

### DIFF
--- a/src/Disqord.Core/Discord/Cdn/Discord.Cdn.cs
+++ b/src/Disqord.Core/Discord/Cdn/Discord.Cdn.cs
@@ -42,7 +42,7 @@ namespace Disqord
             public static string GetGuildBannerUrl(Snowflake guildId, string bannerHash, CdnAssetFormat format = default, int? size = null)
             {
                 var path = $"banners/{guildId}/{bannerHash}";
-                return FormatUrl(path, format, size);
+                return FormatUrl(path, AutomaticGifFormat(format, bannerHash), size);
             }
 
             public static string GetUserBannerUrl(Snowflake userId, string bannerHash, CdnAssetFormat format = default, int? size = null)

--- a/src/Disqord.Core/Entities/Core/Guild/GuildFeatures.Strings.cs
+++ b/src/Disqord.Core/Entities/Core/Guild/GuildFeatures.Strings.cs
@@ -3,6 +3,11 @@ namespace Disqord
     public readonly partial struct GuildFeatures
     {
         /// <summary>
+        ///     The guild can set an animated banner.
+        /// </summary>
+        public const string AnimatedBanner = "ANIMATED_BANNER";
+
+        /// <summary>
         ///     The guild can set an animated icon.
         /// </summary>
         public const string AnimatedIcon = "ANIMATED_ICON";

--- a/src/Disqord.Core/Entities/Core/Guild/GuildFeatures.cs
+++ b/src/Disqord.Core/Entities/Core/Guild/GuildFeatures.cs
@@ -17,6 +17,11 @@ namespace Disqord
     public readonly partial struct GuildFeatures : IReadOnlyList<string>
     {
         /// <summary>
+        ///     Gets whether the guild can set an animated banner.
+        /// </summary>
+        public bool HasAnimatedBanner => Has(AnimatedBanner);
+
+        /// <summary>
         ///     Gets whether the guild can set an animated icon.
         /// </summary>
         public bool HasAnimatedIcon => Has(AnimatedIcon);


### PR DESCRIPTION
## Description

- Added `ANIMATED_BANNER` guild feature.
- Updated `GetGuildBannerUrl` method to account for animated banners.

## Checklist

- [x] I discussed this PR with the maintainer(s) prior to opening it.
- [x] I read the [contributing guidelines](https://github.com/Quahu/Disqord/blob/master/.github/CONTRIBUTING.md).
- [x] I tested the changes in this PR.
