### PR TITLE
Added support for guild boost progress bar

### DIFF
--- a/src/Disqord.Core/Entities/Core/Guild/IGuild.cs
+++ b/src/Disqord.Core/Entities/Core/Guild/IGuild.cs
@@ -170,7 +170,7 @@ namespace Disqord
         IReadOnlyDictionary<Snowflake, IGuildSticker> Stickers { get; }
 
         /// <summary>
-        ///     Gets whether this guild has the premium progress bar enabled.
+        ///     Gets whether this guild has the boost progress bar enabled.
         /// </summary>
         bool IsBoostProgressBarEnabled { get; }
     }

--- a/src/Disqord.Core/Entities/Core/Guild/IGuild.cs
+++ b/src/Disqord.Core/Entities/Core/Guild/IGuild.cs
@@ -168,5 +168,10 @@ namespace Disqord
         ///     Gets the stickers of this guild.
         /// </summary>
         IReadOnlyDictionary<Snowflake, IGuildSticker> Stickers { get; }
+
+        /// <summary>
+        ///     Gets whether this guild has the premium progress bar enabled.
+        /// </summary>
+        bool IsBoostProgressBarEnabled { get; }
     }
 }

--- a/src/Disqord.Core/Entities/Shared/Transient/Guild/TransientGuild.cs
+++ b/src/Disqord.Core/Entities/Shared/Transient/Guild/TransientGuild.cs
@@ -102,6 +102,8 @@ namespace Disqord
         }
         private IReadOnlyDictionary<Snowflake, IGuildSticker> _stickers;
 
+        public bool IsBoostProgressBarEnabled => Model.PremiumProgressBarEnabled;
+
         public TransientGuild(IClient client, GuildJsonModel model)
             : base(client, model)
         { }

--- a/src/Disqord.Core/Models/GuildJsonModel.cs
+++ b/src/Disqord.Core/Models/GuildJsonModel.cs
@@ -121,5 +121,8 @@ namespace Disqord.Models
 
         [JsonProperty("welcome_screen")]
         public Optional<WelcomeScreenJsonModel> WelcomeScreen;
+
+        [JsonProperty("premium_progress_bar_enabled")]
+        public bool PremiumProgressBarEnabled;
     }
 }

--- a/src/Disqord.Gateway/Entities/Cached/CachedGuild.cs
+++ b/src/Disqord.Gateway/Entities/Cached/CachedGuild.cs
@@ -149,6 +149,8 @@ namespace Disqord.Gateway
 
         public IReadOnlyDictionary<Snowflake, IGuildSticker> Stickers { get; private set; }
 
+        public bool IsBoostProgressBarEnabled { get; private set; }
+
         public CachedGuild(IGatewayClient client, GatewayGuildJsonModel model)
             : base(client, model.Id)
         {
@@ -197,6 +199,7 @@ namespace Disqord.Gateway
             PublicUpdatesChannelId = model.PublicUpdatesChannelId;
             MaxVideoMemberCount = model.MaxVideoChannelUsers.GetValueOrNullable();
             NsfwLevel = model.NsfwLevel;
+            IsBoostProgressBarEnabled = model.PremiumProgressBarEnabled;
         }
 
         public void Update(GatewayGuildJsonModel model)

--- a/src/Disqord.Gateway/Entities/Transient/Guild/TransientGatewayGuild.cs
+++ b/src/Disqord.Gateway/Entities/Transient/Guild/TransientGatewayGuild.cs
@@ -102,6 +102,8 @@ namespace Disqord
         }
         private IReadOnlyDictionary<Snowflake, IGuildSticker> _stickers;
 
+        public bool IsBoostProgressBarEnabled => Model.PremiumProgressBarEnabled;
+
         public DateTimeOffset JoinedAt => Model.JoinedAt;
 
         public bool IsLarge => Model.Large;

--- a/src/Disqord.Rest.Api/Content/Json/ModifyGuildJsonRestRequestContent.cs
+++ b/src/Disqord.Rest.Api/Content/Json/ModifyGuildJsonRestRequestContent.cs
@@ -58,5 +58,8 @@ namespace Disqord.Rest.Api
 
         [JsonProperty("description")]
         public Optional<string> Description;
+
+        [JsonProperty("premium_progress_bar_enabled")]
+        public Optional<bool> PremiumProgressBarEnabled;
     }
 }

--- a/src/Disqord.Rest/ActionProperties/Modify/ModifyGuildActionProperties.cs
+++ b/src/Disqord.Rest/ActionProperties/Modify/ModifyGuildActionProperties.cs
@@ -42,6 +42,8 @@ namespace Disqord
 
         public Optional<string> Description { internal get; set; }
 
+        public Optional<bool> IsBoostProgressBarEnabled { internal get; set; }
+
         internal ModifyGuildActionProperties()
         { }
     }

--- a/src/Disqord.Rest/Extensions/RestClientExtensions.Guild.cs
+++ b/src/Disqord.Rest/Extensions/RestClientExtensions.Guild.cs
@@ -59,7 +59,8 @@ namespace Disqord.Rest
                 PublicUpdatesChannelId = properties.PublicUpdatesChannelId,
                 PreferredLocale = Optional.Convert(properties.PreferredLocale, x => x.Name),
                 Features = Optional.Convert(properties.Features, x => x.ToArray()),
-                Description = properties.Description
+                Description = properties.Description,
+                PremiumProgressBarEnabled = properties.IsBoostProgressBarEnabled
             };
 
             var model = await client.ApiClient.ModifyGuildAsync(guildId, content, options, cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
## Description

- Added `IsBoostProgressBarEnabled` to guild entities.
- Added `IsBoostProgressBarEnabled` property to modify guild actions.

## Checklist

- [x] I discussed this PR with the maintainer(s) prior to opening it.
- [x] I read the [contributing guidelines](https://github.com/Quahu/Disqord/blob/master/.github/CONTRIBUTING.md).
- [x] I tested the changes in this PR.
