### PR TITLE
Implemented guild timeouts, modify current member endpoint

### DIFF
--- a/src/Disqord.Core/Entities/Core/AuditLogs/Member/Data/IMemberAuditLogChanges.cs
+++ b/src/Disqord.Core/Entities/Core/AuditLogs/Member/Data/IMemberAuditLogChanges.cs
@@ -1,4 +1,6 @@
-﻿namespace Disqord.AuditLogs
+﻿using System;
+
+namespace Disqord.AuditLogs
 {
     public interface IMemberAuditLogChanges
     {
@@ -7,5 +9,7 @@
         AuditLogChange<bool> IsMuted { get; }
 
         AuditLogChange<bool> IsDeafened { get; }
+
+        AuditLogChange<DateTimeOffset> TimedOutUntil { get; }
     }
 }

--- a/src/Disqord.Core/Entities/Core/Users/IMember.cs
+++ b/src/Disqord.Core/Entities/Core/Users/IMember.cs
@@ -53,7 +53,7 @@ namespace Disqord
         string GuildAvatarHash { get; }
 
         /// <summary>
-        ///     Gets when this member is timed out until.
+        ///     Gets until when this member is timed out.
         ///     Returns <see langword="null"/> if this member has not been timed out.
         /// </summary>
         DateTimeOffset? TimedOutUntil { get; }

--- a/src/Disqord.Core/Entities/Core/Users/IMember.cs
+++ b/src/Disqord.Core/Entities/Core/Users/IMember.cs
@@ -51,5 +51,11 @@ namespace Disqord
         ///     Returns <see langword="null"/> if this member has no guild avatar set.
         /// </summary>
         string GuildAvatarHash { get; }
+
+        /// <summary>
+        ///     Gets when this member is timed out until.
+        ///     Returns <see langword="null"/> if this member has not been timed out.
+        /// </summary>
+        DateTimeOffset? TimedOutUntil { get; }
     }
 }

--- a/src/Disqord.Core/Entities/Shared/Permissions/Guild/GuildPermissions.Values.cs
+++ b/src/Disqord.Core/Entities/Shared/Permissions/Guild/GuildPermissions.Values.cs
@@ -41,6 +41,7 @@
             | Permission.CreatePrivateThreads
             | Permission.UseExternalStickers
             | Permission.SendMessagesInThreads
-            | Permission.StartActivities);
+            | Permission.StartActivities
+            | Permission.ModerateMembers);
     }
 }

--- a/src/Disqord.Core/Entities/Shared/Permissions/Guild/GuildPermissions.cs
+++ b/src/Disqord.Core/Entities/Shared/Permissions/Guild/GuildPermissions.cs
@@ -93,7 +93,7 @@ namespace Disqord
 
         public bool ModerateMembers => Has(Permission.ModerateMembers);
 
-        public Permission Permissions => (Permission) RawValue;
+        public Permission Flags => (Permission) RawValue;
 
         public ulong RawValue { get; }
 

--- a/src/Disqord.Core/Entities/Shared/Permissions/Guild/GuildPermissions.cs
+++ b/src/Disqord.Core/Entities/Shared/Permissions/Guild/GuildPermissions.cs
@@ -91,7 +91,9 @@ namespace Disqord
 
         public bool StartActivities => Has(Permission.StartActivities);
 
-        public Permission Flags => (Permission) RawValue;
+        public bool ModerateMembers => Has(Permission.ModerateMembers);
+
+        public Permission Permissions => (Permission) RawValue;
 
         public ulong RawValue { get; }
 

--- a/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Member/Data/TransientMemberAuditLogChanges.cs
+++ b/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Member/Data/TransientMemberAuditLogChanges.cs
@@ -1,4 +1,5 @@
-﻿using Disqord.Models;
+﻿using System;
+using Disqord.Models;
 using Microsoft.Extensions.Logging;
 
 namespace Disqord.AuditLogs
@@ -10,6 +11,8 @@ namespace Disqord.AuditLogs
         public AuditLogChange<bool> IsMuted { get; }
 
         public AuditLogChange<bool> IsDeafened { get; }
+
+        public AuditLogChange<DateTimeOffset> TimedOutUntil { get; }
 
         public TransientMemberAuditLogChanges(IClient client, AuditLogEntryJsonModel model)
         {
@@ -31,6 +34,11 @@ namespace Disqord.AuditLogs
                     case "deaf":
                     {
                         IsDeafened = AuditLogChange<bool>.Convert(change);
+                        break;
+                    }
+                    case "communication_disabled_until":
+                    {
+                        TimedOutUntil = AuditLogChange<DateTimeOffset>.Convert(change);
                         break;
                     }
                     default:

--- a/src/Disqord.Core/Entities/Shared/Transient/Users/TransientMember.cs
+++ b/src/Disqord.Core/Entities/Shared/Transient/Users/TransientMember.cs
@@ -34,6 +34,9 @@ namespace Disqord
         public string GuildAvatarHash => Model.Avatar.GetValueOrDefault();
 
         /// <inheritdoc/>
+        public DateTimeOffset? TimedOutUntil => Model.CommunicationDisabledUntil.GetValueOrDefault();
+
+        /// <inheritdoc/>
         public new MemberJsonModel Model { get; }
 
         public TransientMember(IClient client, Snowflake guildId, MemberJsonModel model)

--- a/src/Disqord.Core/Enums/Permission.cs
+++ b/src/Disqord.Core/Enums/Permission.cs
@@ -206,6 +206,11 @@ namespace Disqord
         /// <summary>
         ///     Allows starting activities in voice channels.
         /// </summary>
-        StartActivities = 1ul << 39
+        StartActivities = 1ul << 39,
+
+        /// <summary>
+        ///     Allows performing moderation actions on members.
+        /// </summary>
+        ModerateMembers = 1ul << 40
     }
 }

--- a/src/Disqord.Core/Enums/Permission.cs
+++ b/src/Disqord.Core/Enums/Permission.cs
@@ -211,6 +211,10 @@ namespace Disqord
         /// <summary>
         ///     Allows performing moderation actions on members.
         /// </summary>
+        /// <remarks>
+        ///     Note that this permission allows you to, for example, time out a member,
+        ///     but does not allow actions that have their own permission like, for example, <see cref="Permission.KickMembers"/>.
+        /// </remarks>
         ModerateMembers = 1ul << 40
     }
 }

--- a/src/Disqord.Core/Models/MemberJsonModel.cs
+++ b/src/Disqord.Core/Models/MemberJsonModel.cs
@@ -35,5 +35,8 @@ namespace Disqord.Models
 
         [JsonProperty("avatar")]
         public Optional<string> Avatar;
+
+        [JsonProperty("communication_disabled_until")]
+        public Optional<DateTimeOffset?> CommunicationDisabledUntil;
     }
 }

--- a/src/Disqord.Gateway/Entities/Cached/User/CachedMember.cs
+++ b/src/Disqord.Gateway/Entities/Cached/User/CachedMember.cs
@@ -27,6 +27,8 @@ namespace Disqord.Gateway
 
         public string GuildAvatarHash { get; private set; }
 
+        public DateTimeOffset? TimedOutUntil { get; private set; }
+
         public CachedMember(CachedSharedUser sharedUser, Snowflake guildId, MemberJsonModel model)
             : base(sharedUser)
         {
@@ -61,6 +63,10 @@ namespace Disqord.Gateway
 
             if (model.Avatar.HasValue)
                 GuildAvatarHash = model.Avatar.Value;
+
+            // Let's hope discord doesn't screw this up
+            if (model.CommunicationDisabledUntil.HasValue)
+                TimedOutUntil = model.CommunicationDisabledUntil.Value;
         }
     }
 }

--- a/src/Disqord.Gateway/Entities/Cached/User/CachedMember.cs
+++ b/src/Disqord.Gateway/Entities/Cached/User/CachedMember.cs
@@ -64,7 +64,6 @@ namespace Disqord.Gateway
             if (model.Avatar.HasValue)
                 GuildAvatarHash = model.Avatar.Value;
 
-            // Let's hope discord doesn't screw this up
             if (model.CommunicationDisabledUntil.HasValue)
                 TimedOutUntil = model.CommunicationDisabledUntil.Value;
         }

--- a/src/Disqord.Rest.Api/Content/Json/ModifyCurrentMemberJsonRestRequestContent.cs
+++ b/src/Disqord.Rest.Api/Content/Json/ModifyCurrentMemberJsonRestRequestContent.cs
@@ -1,0 +1,10 @@
+﻿using Disqord.Serialization.Json;
+
+namespace Disqord.Rest.Api
+{
+    public class ModifyCurrentMemberJsonRestRequestContent : JsonModelRestRequestContent
+    {
+        [JsonProperty("nick")]
+        public Optional<string> Nick;
+    }
+}

--- a/src/Disqord.Rest.Api/Content/Json/ModifyMemberJsonRestRequestContent.cs
+++ b/src/Disqord.Rest.Api/Content/Json/ModifyMemberJsonRestRequestContent.cs
@@ -1,4 +1,5 @@
-﻿using Disqord.Serialization.Json;
+﻿using System;
+using Disqord.Serialization.Json;
 
 namespace Disqord.Rest.Api
 {
@@ -18,5 +19,8 @@ namespace Disqord.Rest.Api
 
         [JsonProperty("channel_id")]
         public Optional<Snowflake?> ChannelId;
+
+        [JsonProperty("communication_disabled_until")]
+        public Optional<DateTimeOffset?> CommunicationDisabledUntil;
     }
 }

--- a/src/Disqord.Rest.Api/Methods/RestApiClientExtensions.Guild.cs
+++ b/src/Disqord.Rest.Api/Methods/RestApiClientExtensions.Guild.cs
@@ -143,6 +143,14 @@ namespace Disqord.Rest.Api
             return client.ExecuteAsync<MemberJsonModel>(route, content, options, cancellationToken);
         }
 
+        public static Task<MemberJsonModel> ModifyCurrentMemberAsync(this IRestApiClient client,
+            Snowflake guildId, ModifyCurrentMemberJsonRestRequestContent content,
+            IRestRequestOptions options = null, CancellationToken cancellationToken = default)
+        {
+            var route = Format(Route.Guild.ModifyCurrentMember, guildId);
+            return client.ExecuteAsync<MemberJsonModel>(route, content, options, cancellationToken);
+        }
+
         public static Task SetOwnNickAsync(this IRestApiClient client,
             Snowflake guildId, SetOwnNickJsonRestRequestContent content,
             IRestRequestOptions options = null, CancellationToken cancellationToken = default)

--- a/src/Disqord.Rest.Api/Routing/Route.Static.cs
+++ b/src/Disqord.Rest.Api/Routing/Route.Static.cs
@@ -148,6 +148,8 @@ namespace Disqord.Rest.Api
 
             public static readonly Route ModifyMember = Patch("guilds/{0:guild_id}/members/{1:user_id}");
 
+            public static readonly Route ModifyCurrentMember = Patch("guilds/{0:guild_id}/members/@me");
+
             public static readonly Route SetOwnNick = Patch("guilds/{0:guild_id}/members/@me/nick");
 
             public static readonly Route GrantRole = Put("guilds/{0:guild_id}/members/{1:user_id}/roles/{2:role_id}");

--- a/src/Disqord.Rest/ActionProperties/Conversion/ActionPropertiesConversion.Guild.cs
+++ b/src/Disqord.Rest/ActionProperties/Conversion/ActionPropertiesConversion.Guild.cs
@@ -1,13 +1,17 @@
 using System;
+using System.Linq;
+using Disqord.Rest.ActionProperties.Modify;
 using Qommon;
 
 namespace Disqord.Rest.Api
 {
     internal static partial class ActionPropertiesConversion
     {
+
         public static ModifyRoleJsonRestRequestContent ToContent(this Action<ModifyRoleActionProperties> action, out Optional<int> position)
         {
             Guard.IsNotNull(action);
+
             var properties = new ModifyRoleActionProperties();
             action(properties);
 
@@ -22,6 +26,46 @@ namespace Disqord.Rest.Api
                 UnicodeEmoji = Optional.Convert(properties.UnicodeEmoji, emoji => emoji.Name)
             };
             position = properties.Position;
+
+            return content;
+        }
+
+        public static ModifyMemberJsonRestRequestContent ToContent(this Action<ModifyMemberActionProperties> action, out Optional<string> nick)
+        {
+            Guard.IsNotNull(action);
+
+            var properties = new ModifyMemberActionProperties();
+            action(properties);
+
+            nick = properties.Nick;
+
+            if (properties.Nick.HasValue)
+                properties.Nick = Optional<string>.Empty;
+
+            var content = new ModifyMemberJsonRestRequestContent
+            {
+                Nick = properties.Nick,
+                Roles = Optional.Convert(properties.RoleIds, x => x.ToArray()),
+                ChannelId = properties.VoiceChannelId,
+                Mute = properties.Mute,
+                Deaf = properties.Deaf,
+                CommunicationDisabledUntil = properties.TimedOutUntil
+            };
+
+            return content;
+        }
+
+        public static ModifyCurrentMemberJsonRestRequestContent ToContent(this Action<ModifyCurrentMemberActionProperties> action)
+        {
+            Guard.IsNotNull(action);
+
+            var properties = new ModifyCurrentMemberActionProperties();
+            action(properties);
+
+            var content = new ModifyCurrentMemberJsonRestRequestContent
+            {
+                Nick = properties.Nick
+            };
 
             return content;
         }

--- a/src/Disqord.Rest/ActionProperties/Conversion/ActionPropertiesConversion.Guild.cs
+++ b/src/Disqord.Rest/ActionProperties/Conversion/ActionPropertiesConversion.Guild.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Linq;
-using Disqord.Rest.ActionProperties.Modify;
 using Qommon;
 
 namespace Disqord.Rest.Api

--- a/src/Disqord.Rest/ActionProperties/Conversion/ActionPropertiesConversion.Guild.cs
+++ b/src/Disqord.Rest/ActionProperties/Conversion/ActionPropertiesConversion.Guild.cs
@@ -39,9 +39,6 @@ namespace Disqord.Rest.Api
 
             nick = properties.Nick;
 
-            if (properties.Nick.HasValue)
-                properties.Nick = Optional<string>.Empty;
-
             var content = new ModifyMemberJsonRestRequestContent
             {
                 Nick = properties.Nick,

--- a/src/Disqord.Rest/ActionProperties/Conversion/ActionPropertiesConversion.Guild.cs
+++ b/src/Disqord.Rest/ActionProperties/Conversion/ActionPropertiesConversion.Guild.cs
@@ -6,7 +6,6 @@ namespace Disqord.Rest.Api
 {
     internal static partial class ActionPropertiesConversion
     {
-
         public static ModifyRoleJsonRestRequestContent ToContent(this Action<ModifyRoleActionProperties> action, out Optional<int> position)
         {
             Guard.IsNotNull(action);

--- a/src/Disqord.Rest/ActionProperties/Modify/ModifyCurrentMemberActionProperties.cs
+++ b/src/Disqord.Rest/ActionProperties/Modify/ModifyCurrentMemberActionProperties.cs
@@ -1,0 +1,7 @@
+namespace Disqord.Rest.ActionProperties.Modify
+{
+    public sealed class ModifyCurrentMemberActionProperties
+    {
+        public Optional<string> Nick { internal get; set; }
+    }
+}

--- a/src/Disqord.Rest/ActionProperties/Modify/ModifyCurrentMemberActionProperties.cs
+++ b/src/Disqord.Rest/ActionProperties/Modify/ModifyCurrentMemberActionProperties.cs
@@ -1,4 +1,4 @@
-namespace Disqord.Rest.ActionProperties.Modify
+namespace Disqord.Rest
 {
     public sealed class ModifyCurrentMemberActionProperties
     {

--- a/src/Disqord.Rest/ActionProperties/Modify/ModifyMemberActionProperties.cs
+++ b/src/Disqord.Rest/ActionProperties/Modify/ModifyMemberActionProperties.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace Disqord
 {
@@ -14,10 +15,9 @@ namespace Disqord
 
         public Optional<Snowflake?> VoiceChannelId { internal get; set; }
 
-        internal ModifyMemberActionProperties()
-        { }
+        public Optional<DateTimeOffset?> TimedOutUntil { internal get; set; }
 
         internal bool HasValues
-            => Nick.HasValue || RoleIds.HasValue || Mute.HasValue || Deaf.HasValue || VoiceChannelId.HasValue;
+            => Nick.HasValue || RoleIds.HasValue || Mute.HasValue || Deaf.HasValue || VoiceChannelId.HasValue || TimedOutUntil.HasValue;
     }
 }

--- a/src/Disqord.Rest/Extensions/Entity/RestEntityExtensions.Guild.cs
+++ b/src/Disqord.Rest/Extensions/Entity/RestEntityExtensions.Guild.cs
@@ -4,7 +4,6 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Disqord.AuditLogs;
-using Disqord.Rest.ActionProperties.Modify;
 using Disqord.Rest.Pagination;
 
 namespace Disqord.Rest

--- a/src/Disqord.Rest/Extensions/Entity/RestEntityExtensions.Guild.cs
+++ b/src/Disqord.Rest/Extensions/Entity/RestEntityExtensions.Guild.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Disqord.AuditLogs;
+using Disqord.Rest.ActionProperties.Modify;
 using Disqord.Rest.Pagination;
 
 namespace Disqord.Rest
@@ -142,6 +143,7 @@ namespace Disqord.Rest
             return client.SearchMembersAsync(guild.Id, query, limit, options, cancellationToken);
         }
 
+        [Obsolete("The SetCurrentMemberNickAsync method is deprecated in favour of ModifyCurrentMemberAsync, please use it instead.")]
         public static Task SetCurrentMemberNickAsync(this IGuild guild,
             string nick,
             IRestRequestOptions options = null, CancellationToken cancellationToken = default)
@@ -156,6 +158,14 @@ namespace Disqord.Rest
         {
             var client = guild.GetRestClient();
             return client.ModifyMemberAsync(guild.Id, memberId, action, options, cancellationToken);
+        }
+
+        public static Task<IMember> ModifyCurrentMemberAsync(this IGuild guild,
+            Action<ModifyCurrentMemberActionProperties> action,
+            IRestRequestOptions options = null, CancellationToken cancellationToken = default)
+        {
+            var client = guild.GetRestClient();
+            return client.ModifyCurrentMemberAsync(guild.Id, action, options, cancellationToken);
         }
 
         public static Task GrantRoleAsync(this IGuild guild,

--- a/src/Disqord.Rest/Extensions/Entity/RestEntityExtensions.Guild.cs
+++ b/src/Disqord.Rest/Extensions/Entity/RestEntityExtensions.Guild.cs
@@ -143,7 +143,7 @@ namespace Disqord.Rest
             return client.SearchMembersAsync(guild.Id, query, limit, options, cancellationToken);
         }
 
-        [Obsolete("The SetCurrentMemberNickAsync method is deprecated in favour of ModifyCurrentMemberAsync, please use it instead.")]
+        [Obsolete("Use ModifyCurrentMemberAsync() instead.")]
         public static Task SetCurrentMemberNickAsync(this IGuild guild,
             string nick,
             IRestRequestOptions options = null, CancellationToken cancellationToken = default)

--- a/src/Disqord.Rest/Extensions/RestClientExtensions.Guild.cs
+++ b/src/Disqord.Rest/Extensions/RestClientExtensions.Guild.cs
@@ -281,7 +281,10 @@ namespace Disqord.Rest
             if (nick.HasValue && client.ApiClient.Token is BotToken botToken)
             {
                 if (memberId == botToken.Id)
+                {
                     await client.ModifyCurrentMemberAsync(guildId, x => x.Nick = nick, options, cancellationToken).ConfigureAwait(false);
+                    content.Nick = Optional<string>.Empty;
+                }
             }
 
             var model = await client.ApiClient.ModifyMemberAsync(guildId, memberId, content, options, cancellationToken).ConfigureAwait(false);

--- a/src/Disqord.Rest/Extensions/RestClientExtensions.Guild.cs
+++ b/src/Disqord.Rest/Extensions/RestClientExtensions.Guild.cs
@@ -5,7 +5,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Disqord.Http;
 using Disqord.Models;
-using Disqord.Rest.ActionProperties.Modify;
 using Disqord.Rest.Api;
 using Disqord.Rest.Pagination;
 using Qommon;

--- a/src/Disqord.Rest/Extensions/RestClientExtensions.Guild.cs
+++ b/src/Disqord.Rest/Extensions/RestClientExtensions.Guild.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Disqord.Http;
 using Disqord.Models;
+using Disqord.Rest.ActionProperties.Modify;
 using Disqord.Rest.Api;
 using Disqord.Rest.Pagination;
 using Qommon;
@@ -271,6 +272,32 @@ namespace Disqord.Rest
             return new TransientMember(client, guildId, model);
         }
 
+        public static async Task<IMember> ModifyMemberAsync(this IRestClient client,
+            Snowflake guildId, Snowflake memberId, Action<ModifyMemberActionProperties> action,
+            IRestRequestOptions options = null, CancellationToken cancellationToken = default)
+        {
+            var content = action.ToContent(out var nick);
+
+            if (nick.HasValue && client.ApiClient.Token is BotToken botToken)
+            {
+                if (memberId == botToken.Id)
+                    await client.ModifyCurrentMemberAsync(guildId, x => x.Nick = nick, options, cancellationToken).ConfigureAwait(false);
+            }
+
+            var model = await client.ApiClient.ModifyMemberAsync(guildId, memberId, content, options, cancellationToken).ConfigureAwait(false);
+            return new TransientMember(client, guildId, model);
+        }
+
+        public static async Task<IMember> ModifyCurrentMemberAsync(this IRestClient client,
+            Snowflake guildId, Action<ModifyCurrentMemberActionProperties> action,
+            IRestRequestOptions options = null, CancellationToken cancellationToken = default)
+        {
+            var content = action.ToContent();
+            var model = await client.ApiClient.ModifyCurrentMemberAsync(guildId, content, options, cancellationToken).ConfigureAwait(false);
+            return new TransientMember(client, guildId, model);
+        }
+
+        [Obsolete("Use ModifyCurrentMemberAsync() instead.")]
         public static Task SetCurrentMemberNickAsync(this IRestClient client,
             Snowflake guildId, string nick,
             IRestRequestOptions options = null, CancellationToken cancellationToken = default)
@@ -281,36 +308,6 @@ namespace Disqord.Rest
             };
 
             return client.ApiClient.SetOwnNickAsync(guildId, content, options, cancellationToken);
-        }
-
-        public static async Task<IMember> ModifyMemberAsync(this IRestClient client,
-            Snowflake guildId, Snowflake memberId, Action<ModifyMemberActionProperties> action,
-            IRestRequestOptions options = null, CancellationToken cancellationToken = default)
-        {
-            Guard.IsNotNull(action);
-
-            var properties = new ModifyMemberActionProperties();
-            action(properties);
-            if (properties.Nick.HasValue && client.ApiClient.Token is BotToken botToken)
-            {
-                if (memberId == botToken.Id)
-                {
-                    await client.SetCurrentMemberNickAsync(guildId, properties.Nick.Value, options, cancellationToken).ConfigureAwait(false);
-                    properties.Nick = Optional<string>.Empty;
-                }
-            }
-
-            var content = new ModifyMemberJsonRestRequestContent
-            {
-                Nick = properties.Nick,
-                Roles = Optional.Convert(properties.RoleIds, x => x.ToArray()),
-                ChannelId = properties.VoiceChannelId,
-                Mute = properties.Mute,
-                Deaf = properties.Deaf
-            };
-
-            var model = await client.ApiClient.ModifyMemberAsync(guildId, memberId, content, options, cancellationToken).ConfigureAwait(false);
-            return new TransientMember(client, guildId, model);
         }
 
         public static Task GrantRoleAsync(this IRestClient client,

--- a/src/Disqord.Test/Program.cs
+++ b/src/Disqord.Test/Program.cs
@@ -1,10 +1,7 @@
 using System;
-using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
-using System.Linq.Expressions;
 using Disqord.Bot.Hosting;
-using Disqord.Gateway.Api;
+using Disqord.Gateway;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;


### PR DESCRIPTION
## Description

- Implemented modify current member endpoint and rest extensions.
- Added `TimedOutUntil` property to member entity.
- Marked `SetCurrentMemberNickAsync` as obsolete.
- Added `ModerateMembers` guild permission.
- Added a new audit log change key.

## Checklist

- [x] I discussed this PR with the maintainer(s) prior to opening it.
- [x] I read the [contributing guidelines](https://github.com/Quahu/Disqord/blob/master/.github/CONTRIBUTING.md).
- [x] I tested the changes in this PR.
