### PR TITLE
Added missing audit log entities and improved docs

### DIFF
--- a/src/Disqord.Core/Entities/Core/AuditLogs/ITargetedAuditLog.cs
+++ b/src/Disqord.Core/Entities/Core/AuditLogs/ITargetedAuditLog.cs
@@ -1,6 +1,6 @@
 namespace Disqord.AuditLogs
 {
-    public interface ITargetedAuditLog<TTarget>
+    public interface ITargetedAuditLog<TTarget> : IAuditLog
         where TTarget : ISnowflakeEntity
     {
         /// <summary>
@@ -9,5 +9,4 @@ namespace Disqord.AuditLogs
         /// </summary>
         TTarget Target { get; }
     }
-
 }

--- a/src/Disqord.Core/Entities/Core/AuditLogs/ITargetedAuditLog.cs
+++ b/src/Disqord.Core/Entities/Core/AuditLogs/ITargetedAuditLog.cs
@@ -1,0 +1,13 @@
+namespace Disqord.AuditLogs
+{
+    public interface ITargetedAuditLog<TTarget>
+        where TTarget : ISnowflakeEntity
+    {
+        /// <summary>
+        ///     Gets the entity this audit log is targeting.
+        ///     Returns <see langword="null"/> if the entity was not provided with the audit log.
+        /// </summary>
+        TTarget Target { get; }
+    }
+
+}

--- a/src/Disqord.Core/Entities/Core/AuditLogs/Member/IBotAddedAuditLog.cs
+++ b/src/Disqord.Core/Entities/Core/AuditLogs/Member/IBotAddedAuditLog.cs
@@ -1,11 +1,5 @@
 ﻿namespace Disqord.AuditLogs
 {
-    public interface IBotAddedAuditLog : IAuditLog
-    {
-        /// <summary>
-        ///     Gets the bot user this audit log is targeting.
-        ///     Returns <see langword="null"/> if the user was not provided with the audit log.
-        /// </summary>
-        IUser User { get; }
-    }
+    public interface IBotAddedAuditLog : IAuditLog, ITargetedAuditLog<IUser>
+    { }
 }

--- a/src/Disqord.Core/Entities/Core/AuditLogs/Member/IBotAddedAuditLog.cs
+++ b/src/Disqord.Core/Entities/Core/AuditLogs/Member/IBotAddedAuditLog.cs
@@ -6,6 +6,6 @@
         ///     Gets the bot user this audit log is targeting.
         ///     Returns <see langword="null"/> if the user was not provided with the audit log.
         /// </summary>
-        IUser Bot { get; }
+        IUser User { get; }
     }
 }

--- a/src/Disqord.Core/Entities/Core/AuditLogs/Member/IBotAddedAuditLog.cs
+++ b/src/Disqord.Core/Entities/Core/AuditLogs/Member/IBotAddedAuditLog.cs
@@ -1,5 +1,11 @@
 ﻿namespace Disqord.AuditLogs
 {
     public interface IBotAddedAuditLog : IAuditLog
-    { }
+    {
+        /// <summary>
+        ///     Gets the bot user this audit log is targeting.
+        ///     Returns <see langword="null"/> if the user was not provided with the audit log.
+        /// </summary>
+        IUser Bot { get; }
+    }
 }

--- a/src/Disqord.Core/Entities/Core/AuditLogs/Member/IBotAddedAuditLog.cs
+++ b/src/Disqord.Core/Entities/Core/AuditLogs/Member/IBotAddedAuditLog.cs
@@ -1,5 +1,5 @@
 ﻿namespace Disqord.AuditLogs
 {
-    public interface IBotAddedAuditLog : IAuditLog, ITargetedAuditLog<IUser>
+    public interface IBotAddedAuditLog : ITargetedAuditLog<IUser>
     { }
 }

--- a/src/Disqord.Core/Entities/Core/AuditLogs/Member/IMemberBannedAuditLog.cs
+++ b/src/Disqord.Core/Entities/Core/AuditLogs/Member/IMemberBannedAuditLog.cs
@@ -1,5 +1,5 @@
 ﻿namespace Disqord.AuditLogs
 {
-    public interface IMemberBannedAuditLog : IAuditLog, ITargetedAuditLog<IUser>
+    public interface IMemberBannedAuditLog : ITargetedAuditLog<IUser>
     { }
 }

--- a/src/Disqord.Core/Entities/Core/AuditLogs/Member/IMemberBannedAuditLog.cs
+++ b/src/Disqord.Core/Entities/Core/AuditLogs/Member/IMemberBannedAuditLog.cs
@@ -1,11 +1,5 @@
 ﻿namespace Disqord.AuditLogs
 {
-    public interface IMemberBannedAuditLog : IAuditLog
-    {
-        /// <summary>
-        ///     Gets the user this audit log is targeting.
-        ///     Returns <see langword="null"/> if the user was not provided with the audit log.
-        /// </summary>
-        IUser User { get; }
-    }
+    public interface IMemberBannedAuditLog : IAuditLog, ITargetedAuditLog<IUser>
+    { }
 }

--- a/src/Disqord.Core/Entities/Core/AuditLogs/Member/IMemberBannedAuditLog.cs
+++ b/src/Disqord.Core/Entities/Core/AuditLogs/Member/IMemberBannedAuditLog.cs
@@ -1,5 +1,11 @@
 ﻿namespace Disqord.AuditLogs
 {
     public interface IMemberBannedAuditLog : IAuditLog
-    { }
+    {
+        /// <summary>
+        ///     Gets the user this audit log is targeting.
+        ///     Returns <see langword="null"/> if the user was not provided with the audit log.
+        /// </summary>
+        IUser User { get; }
+    }
 }

--- a/src/Disqord.Core/Entities/Core/AuditLogs/Member/IMemberKickedAuditLog.cs
+++ b/src/Disqord.Core/Entities/Core/AuditLogs/Member/IMemberKickedAuditLog.cs
@@ -1,5 +1,11 @@
 ﻿namespace Disqord.AuditLogs
 {
     public interface IMemberKickedAuditLog : IAuditLog
-    { }
+    {
+        /// <summary>
+        ///     Gets the user this audit log is targeting.
+        ///     Returns <see langword="null"/> if the user was not provided with the audit log.
+        /// </summary>
+        IUser User { get; }
+    }
 }

--- a/src/Disqord.Core/Entities/Core/AuditLogs/Member/IMemberKickedAuditLog.cs
+++ b/src/Disqord.Core/Entities/Core/AuditLogs/Member/IMemberKickedAuditLog.cs
@@ -1,5 +1,5 @@
 ﻿namespace Disqord.AuditLogs
 {
-    public interface IMemberKickedAuditLog : IAuditLog, ITargetedAuditLog<IUser>
+    public interface IMemberKickedAuditLog : ITargetedAuditLog<IUser>
     { }
 }

--- a/src/Disqord.Core/Entities/Core/AuditLogs/Member/IMemberKickedAuditLog.cs
+++ b/src/Disqord.Core/Entities/Core/AuditLogs/Member/IMemberKickedAuditLog.cs
@@ -1,11 +1,5 @@
 ﻿namespace Disqord.AuditLogs
 {
-    public interface IMemberKickedAuditLog : IAuditLog
-    {
-        /// <summary>
-        ///     Gets the user this audit log is targeting.
-        ///     Returns <see langword="null"/> if the user was not provided with the audit log.
-        /// </summary>
-        IUser User { get; }
-    }
+    public interface IMemberKickedAuditLog : IAuditLog, ITargetedAuditLog<IUser>
+    { }
 }

--- a/src/Disqord.Core/Entities/Core/AuditLogs/Member/IMemberRolesUpdatedAuditLog.cs
+++ b/src/Disqord.Core/Entities/Core/AuditLogs/Member/IMemberRolesUpdatedAuditLog.cs
@@ -2,7 +2,7 @@
 
 namespace Disqord.AuditLogs
 {
-    public interface IMemberRolesUpdatedAuditLog : IAuditLog, ITargetedAuditLog<IUser>
+    public interface IMemberRolesUpdatedAuditLog : ITargetedAuditLog<IUser>
     {
         /// <summary>
         ///     Gets the names of the roles granted keyed by their IDs.

--- a/src/Disqord.Core/Entities/Core/AuditLogs/Member/IMemberRolesUpdatedAuditLog.cs
+++ b/src/Disqord.Core/Entities/Core/AuditLogs/Member/IMemberRolesUpdatedAuditLog.cs
@@ -2,7 +2,7 @@
 
 namespace Disqord.AuditLogs
 {
-    public interface IMemberRolesUpdatedAuditLog : IAuditLog
+    public interface IMemberRolesUpdatedAuditLog : IAuditLog, ITargetedAuditLog<IUser>
     {
         /// <summary>
         ///     Gets the names of the roles granted keyed by their IDs.
@@ -13,11 +13,5 @@ namespace Disqord.AuditLogs
         ///     Gets the names of the roles revoked keyed by their IDs.
         /// </summary>
         Optional<IReadOnlyDictionary<Snowflake, string>> RevokedRoles { get; }
-
-        /// <summary>
-        ///     Gets the user this audit log is targeting.
-        ///     Returns <see langword="null"/> if the user was not provided with the audit log.
-        /// </summary>
-        IUser User { get; }
     }
 }

--- a/src/Disqord.Core/Entities/Core/AuditLogs/Member/IMemberRolesUpdatedAuditLog.cs
+++ b/src/Disqord.Core/Entities/Core/AuditLogs/Member/IMemberRolesUpdatedAuditLog.cs
@@ -4,8 +4,20 @@ namespace Disqord.AuditLogs
 {
     public interface IMemberRolesUpdatedAuditLog : IAuditLog
     {
+        /// <summary>
+        ///     Gets the names of the roles granted keyed by their IDs.
+        /// </summary>
         Optional<IReadOnlyDictionary<Snowflake, string>> RolesGranted { get; }
 
+        /// <summary>
+        ///     Gets the names of the roles revoked keyed by their IDs.
+        /// </summary>
         Optional<IReadOnlyDictionary<Snowflake, string>> RolesRevoked { get; }
+
+        /// <summary>
+        ///     Gets the user this audit log is targeting.
+        ///     Returns <see langword="null"/> if the user was not provided with the audit log.
+        /// </summary>
+        IUser User { get; }
     }
 }

--- a/src/Disqord.Core/Entities/Core/AuditLogs/Member/IMemberRolesUpdatedAuditLog.cs
+++ b/src/Disqord.Core/Entities/Core/AuditLogs/Member/IMemberRolesUpdatedAuditLog.cs
@@ -7,12 +7,12 @@ namespace Disqord.AuditLogs
         /// <summary>
         ///     Gets the names of the roles granted keyed by their IDs.
         /// </summary>
-        Optional<IReadOnlyDictionary<Snowflake, string>> RolesGranted { get; }
+        Optional<IReadOnlyDictionary<Snowflake, string>> GrantedRoles { get; }
 
         /// <summary>
         ///     Gets the names of the roles revoked keyed by their IDs.
         /// </summary>
-        Optional<IReadOnlyDictionary<Snowflake, string>> RolesRevoked { get; }
+        Optional<IReadOnlyDictionary<Snowflake, string>> RevokedRoles { get; }
 
         /// <summary>
         ///     Gets the user this audit log is targeting.

--- a/src/Disqord.Core/Entities/Core/AuditLogs/Member/IMemberUnbannedAuditLog.cs
+++ b/src/Disqord.Core/Entities/Core/AuditLogs/Member/IMemberUnbannedAuditLog.cs
@@ -1,11 +1,5 @@
 ﻿namespace Disqord.AuditLogs
 {
-    public interface IMemberUnbannedAuditLog : IAuditLog
-    {
-        /// <summary>
-        ///     Gets the user this audit log is targeting.
-        ///     Returns <see langword="null"/> if the user was not provided with the audit log.
-        /// </summary>
-        IUser User { get; }
-    }
+    public interface IMemberUnbannedAuditLog : IAuditLog, ITargetedAuditLog<IUser>
+    { }
 }

--- a/src/Disqord.Core/Entities/Core/AuditLogs/Member/IMemberUnbannedAuditLog.cs
+++ b/src/Disqord.Core/Entities/Core/AuditLogs/Member/IMemberUnbannedAuditLog.cs
@@ -1,5 +1,11 @@
 ﻿namespace Disqord.AuditLogs
 {
     public interface IMemberUnbannedAuditLog : IAuditLog
-    { }
+    {
+        /// <summary>
+        ///     Gets the user this audit log is targeting.
+        ///     Returns <see langword="null"/> if the user was not provided with the audit log.
+        /// </summary>
+        IUser User { get; }
+    }
 }

--- a/src/Disqord.Core/Entities/Core/AuditLogs/Member/IMemberUnbannedAuditLog.cs
+++ b/src/Disqord.Core/Entities/Core/AuditLogs/Member/IMemberUnbannedAuditLog.cs
@@ -1,5 +1,5 @@
 ﻿namespace Disqord.AuditLogs
 {
-    public interface IMemberUnbannedAuditLog : IAuditLog, ITargetedAuditLog<IUser>
+    public interface IMemberUnbannedAuditLog : ITargetedAuditLog<IUser>
     { }
 }

--- a/src/Disqord.Core/Entities/Core/AuditLogs/Member/IMemberUpdatedAuditLog.cs
+++ b/src/Disqord.Core/Entities/Core/AuditLogs/Member/IMemberUpdatedAuditLog.cs
@@ -1,5 +1,11 @@
 ﻿namespace Disqord.AuditLogs
 {
     public interface IMemberUpdatedAuditLog : IChangesAuditLog<IMemberAuditLogChanges>
-    { }
+    {
+        /// <summary>
+        ///     Gets the user this audit log is targeting.
+        ///     Returns <see langword="null"/> if the user was not provided with the audit log.
+        /// </summary>
+        IUser User { get; }
+    }
 }

--- a/src/Disqord.Core/Entities/Core/AuditLogs/Member/IMemberUpdatedAuditLog.cs
+++ b/src/Disqord.Core/Entities/Core/AuditLogs/Member/IMemberUpdatedAuditLog.cs
@@ -1,11 +1,5 @@
 ﻿namespace Disqord.AuditLogs
 {
-    public interface IMemberUpdatedAuditLog : IChangesAuditLog<IMemberAuditLogChanges>
-    {
-        /// <summary>
-        ///     Gets the user this audit log is targeting.
-        ///     Returns <see langword="null"/> if the user was not provided with the audit log.
-        /// </summary>
-        IUser User { get; }
-    }
+    public interface IMemberUpdatedAuditLog : IChangesAuditLog<IMemberAuditLogChanges>, ITargetedAuditLog<IUser>
+    { }
 }

--- a/src/Disqord.Core/Entities/Core/AuditLogs/Member/IMembersDisconnectedAuditLog.cs
+++ b/src/Disqord.Core/Entities/Core/AuditLogs/Member/IMembersDisconnectedAuditLog.cs
@@ -2,6 +2,9 @@
 {
     public interface IMembersDisconnectedAuditLog : IAuditLog
     {
+        /// <summary>
+        ///     Gets the count of members which were disconnected.
+        /// </summary>
         int Count { get; }
     }
 }

--- a/src/Disqord.Core/Entities/Core/AuditLogs/Member/IMembersDisconnectedAuditLog.cs
+++ b/src/Disqord.Core/Entities/Core/AuditLogs/Member/IMembersDisconnectedAuditLog.cs
@@ -3,7 +3,7 @@
     public interface IMembersDisconnectedAuditLog : IAuditLog
     {
         /// <summary>
-        ///     Gets the count of members which were disconnected.
+        ///     Gets the amount of members which were disconnected.
         /// </summary>
         int Count { get; }
     }

--- a/src/Disqord.Core/Entities/Core/AuditLogs/Member/IMembersMovedAuditLog.cs
+++ b/src/Disqord.Core/Entities/Core/AuditLogs/Member/IMembersMovedAuditLog.cs
@@ -5,11 +5,11 @@
         /// <summary>
         ///     Gets the ID of the channel to which the members were moved.
         /// </summary>
-        public Snowflake ChannelId { get; }
+        Snowflake ChannelId { get; }
 
         /// <summary>
-        ///     Gets the count of members which were moved.
+        ///     Gets the amount of members which were moved.
         /// </summary>
-        public int Count { get; }
+        int Count { get; }
     }
 }

--- a/src/Disqord.Core/Entities/Core/AuditLogs/Member/IMembersMovedAuditLog.cs
+++ b/src/Disqord.Core/Entities/Core/AuditLogs/Member/IMembersMovedAuditLog.cs
@@ -2,8 +2,14 @@
 {
     public interface IMembersMovedAuditLog : IAuditLog
     {
+        /// <summary>
+        ///     Gets the ID of the channel to which the members were moved.
+        /// </summary>
         public Snowflake ChannelId { get; }
 
+        /// <summary>
+        ///     Gets the count of members which were moved.
+        /// </summary>
         public int Count { get; }
     }
 }

--- a/src/Disqord.Core/Entities/Core/AuditLogs/Member/IMembersPrunedAuditLog.cs
+++ b/src/Disqord.Core/Entities/Core/AuditLogs/Member/IMembersPrunedAuditLog.cs
@@ -2,8 +2,14 @@
 {
     public interface IMembersPrunedAuditLog : IAuditLog
     {
+        /// <summary>
+        ///     Gets the number of days after which inactive members were pruned.
+        /// </summary>
         int Days { get; }
 
+        /// <summary>
+        ///     Gets the count of inactive members which were pruned.
+        /// </summary>
         int Count { get; }
     }
 }

--- a/src/Disqord.Core/Entities/Core/AuditLogs/Member/IMembersPrunedAuditLog.cs
+++ b/src/Disqord.Core/Entities/Core/AuditLogs/Member/IMembersPrunedAuditLog.cs
@@ -8,7 +8,7 @@
         int Days { get; }
 
         /// <summary>
-        ///     Gets the count of inactive members which were pruned.
+        ///     Gets the amount of inactive members which were pruned.
         /// </summary>
         int Count { get; }
     }

--- a/src/Disqord.Core/Entities/Core/AuditLogs/Message/IMessagePinnedAuditLog.cs
+++ b/src/Disqord.Core/Entities/Core/AuditLogs/Message/IMessagePinnedAuditLog.cs
@@ -2,8 +2,14 @@
 {
     public interface IMessagePinnedAuditLog : IAuditLog
     {
+        /// <summary>
+        ///     Gets the ID of the channel in which the message was pinned.
+        /// </summary>
         Snowflake ChannelId { get; }
 
+        /// <summary>
+        ///     Gets the ID of the message of the message which was pinned.
+        /// </summary>
         Snowflake MessageId { get; }
     }
 }

--- a/src/Disqord.Core/Entities/Core/AuditLogs/Message/IMessageUnpinnedAuditLog.cs
+++ b/src/Disqord.Core/Entities/Core/AuditLogs/Message/IMessageUnpinnedAuditLog.cs
@@ -2,8 +2,14 @@
 {
     public interface IMessageUnpinnedAuditLog : IAuditLog
     {
+        /// <summary>
+        ///     Gets the ID of the channel in which the message was unpinned.
+        /// </summary>
         Snowflake ChannelId { get; }
 
+        /// <summary>
+        ///     Gets the ID of the message of the message which was unpinned.
+        /// </summary>
         Snowflake MessageId { get; }
     }
 }

--- a/src/Disqord.Core/Entities/Core/AuditLogs/Message/IMessagesBulkDeletedAuditLog.cs
+++ b/src/Disqord.Core/Entities/Core/AuditLogs/Message/IMessagesBulkDeletedAuditLog.cs
@@ -2,8 +2,14 @@
 {
     public interface IMessagesBulkDeletedAuditLog : IAuditLog
     {
+        /// <summary>
+        ///     Gets the ID of the channel in which the messages were deleted.
+        /// </summary>
         Snowflake ChannelId { get; }
 
+        /// <summary>
+        ///     Gets the count of the messages which were deleted.
+        /// </summary>
         int Count { get; }
     }
 }

--- a/src/Disqord.Core/Entities/Core/AuditLogs/Message/IMessagesBulkDeletedAuditLog.cs
+++ b/src/Disqord.Core/Entities/Core/AuditLogs/Message/IMessagesBulkDeletedAuditLog.cs
@@ -8,7 +8,7 @@
         Snowflake ChannelId { get; }
 
         /// <summary>
-        ///     Gets the count of the messages which were deleted.
+        ///     Gets the amount of the messages which were deleted.
         /// </summary>
         int Count { get; }
     }

--- a/src/Disqord.Core/Entities/Core/AuditLogs/Message/IMessagesDeletedAuditLog.cs
+++ b/src/Disqord.Core/Entities/Core/AuditLogs/Message/IMessagesDeletedAuditLog.cs
@@ -2,8 +2,14 @@
 {
     public interface IMessagesDeletedAuditLog : IAuditLog
     {
+        /// <summary>
+        ///     Gets the ID of the channel in which the messages were deleted.
+        /// </summary>
         Snowflake ChannelId { get; }
 
+        /// <summary>
+        ///     Gets the count of the messages which were deleted.
+        /// </summary>
         int Count { get; }
     }
 }

--- a/src/Disqord.Core/Entities/Core/AuditLogs/Message/IMessagesDeletedAuditLog.cs
+++ b/src/Disqord.Core/Entities/Core/AuditLogs/Message/IMessagesDeletedAuditLog.cs
@@ -8,7 +8,7 @@
         Snowflake ChannelId { get; }
 
         /// <summary>
-        ///     Gets the count of the messages which were deleted.
+        ///     Gets the amount of the messages which were deleted.
         /// </summary>
         int Count { get; }
     }

--- a/src/Disqord.Core/Entities/Core/AuditLogs/Thread/IThreadCreatedAuditLog.cs
+++ b/src/Disqord.Core/Entities/Core/AuditLogs/Thread/IThreadCreatedAuditLog.cs
@@ -1,5 +1,11 @@
 namespace Disqord.AuditLogs
 {
     public interface IThreadCreatedAuditLog : IDataAuditLog<IThreadAuditLogData>
-    { }
+    {
+        /// <summary>
+        ///     Gets the thread this audit log is targeting.
+        ///     Returns <see langword="null"/> if the thread was not provided with the audit log.
+        /// </summary>
+        IThreadChannel Thread { get; }
+    }
 }

--- a/src/Disqord.Core/Entities/Core/AuditLogs/Thread/IThreadCreatedAuditLog.cs
+++ b/src/Disqord.Core/Entities/Core/AuditLogs/Thread/IThreadCreatedAuditLog.cs
@@ -1,11 +1,5 @@
 namespace Disqord.AuditLogs
 {
-    public interface IThreadCreatedAuditLog : IDataAuditLog<IThreadAuditLogData>
-    {
-        /// <summary>
-        ///     Gets the thread this audit log is targeting.
-        ///     Returns <see langword="null"/> if the thread was not provided with the audit log.
-        /// </summary>
-        IThreadChannel Thread { get; }
-    }
+    public interface IThreadCreatedAuditLog : IDataAuditLog<IThreadAuditLogData>, ITargetedAuditLog<IThreadChannel>
+    { }
 }

--- a/src/Disqord.Core/Entities/Core/AuditLogs/Thread/IThreadUpdatedAuditLog.cs
+++ b/src/Disqord.Core/Entities/Core/AuditLogs/Thread/IThreadUpdatedAuditLog.cs
@@ -1,11 +1,5 @@
 namespace Disqord.AuditLogs
 {
-    public interface IThreadUpdatedAuditLog : IChangesAuditLog<IThreadAuditLogChanges>
-    {
-        /// <summary>
-        ///     Gets the thread this audit log is targeting.
-        ///     Returns <see langword="null"/> if the thread was not provided with the audit log.
-        /// </summary>
-        IThreadChannel Thread { get; }
-    }
+    public interface IThreadUpdatedAuditLog : IChangesAuditLog<IThreadAuditLogChanges>, ITargetedAuditLog<IThreadChannel>
+    { }
 }

--- a/src/Disqord.Core/Entities/Core/AuditLogs/Thread/IThreadUpdatedAuditLog.cs
+++ b/src/Disqord.Core/Entities/Core/AuditLogs/Thread/IThreadUpdatedAuditLog.cs
@@ -1,5 +1,11 @@
 namespace Disqord.AuditLogs
 {
     public interface IThreadUpdatedAuditLog : IChangesAuditLog<IThreadAuditLogChanges>
-    { }
+    {
+        /// <summary>
+        ///     Gets the thread this audit log is targeting.
+        ///     Returns <see langword="null"/> if the thread was not provided with the audit log.
+        /// </summary>
+        IThreadChannel Thread { get; }
+    }
 }

--- a/src/Disqord.Core/Entities/Core/AuditLogs/Webhook/IWebhookCreatedAuditLog.cs
+++ b/src/Disqord.Core/Entities/Core/AuditLogs/Webhook/IWebhookCreatedAuditLog.cs
@@ -1,5 +1,11 @@
 ﻿namespace Disqord.AuditLogs
 {
     public interface IWebhookCreatedAuditLog : IDataAuditLog<IWebhookAuditLogData>
-    { }
+    {
+        /// <summary>
+        ///     Gets the webhook this audit log is targeting.
+        ///     Returns <see langword="null"/> if the webhook was not provided with the audit log.
+        /// </summary>
+        IWebhook Webhook { get; }
+    }
 }

--- a/src/Disqord.Core/Entities/Core/AuditLogs/Webhook/IWebhookCreatedAuditLog.cs
+++ b/src/Disqord.Core/Entities/Core/AuditLogs/Webhook/IWebhookCreatedAuditLog.cs
@@ -1,11 +1,5 @@
 ﻿namespace Disqord.AuditLogs
 {
-    public interface IWebhookCreatedAuditLog : IDataAuditLog<IWebhookAuditLogData>
-    {
-        /// <summary>
-        ///     Gets the webhook this audit log is targeting.
-        ///     Returns <see langword="null"/> if the webhook was not provided with the audit log.
-        /// </summary>
-        IWebhook Webhook { get; }
-    }
+    public interface IWebhookCreatedAuditLog : IDataAuditLog<IWebhookAuditLogData>, ITargetedAuditLog<IWebhook>
+    { }
 }

--- a/src/Disqord.Core/Entities/Core/AuditLogs/Webhook/IWebhookUpdatedAuditLog.cs
+++ b/src/Disqord.Core/Entities/Core/AuditLogs/Webhook/IWebhookUpdatedAuditLog.cs
@@ -1,11 +1,5 @@
 ﻿namespace Disqord.AuditLogs
 {
-    public interface IWebhookUpdatedAuditLog : IChangesAuditLog<IWebhookAuditLogChanges>
-    {
-        /// <summary>
-        ///     Gets the webhook this audit log is targeting.
-        ///     Returns <see langword="null"/> if the webhook was not provided with the audit log.
-        /// </summary>
-        IWebhook Webhook { get; }
-    }
+    public interface IWebhookUpdatedAuditLog : IChangesAuditLog<IWebhookAuditLogChanges>, ITargetedAuditLog<IWebhook>
+    { }
 }

--- a/src/Disqord.Core/Entities/Core/AuditLogs/Webhook/IWebhookUpdatedAuditLog.cs
+++ b/src/Disqord.Core/Entities/Core/AuditLogs/Webhook/IWebhookUpdatedAuditLog.cs
@@ -1,5 +1,11 @@
 ﻿namespace Disqord.AuditLogs
 {
     public interface IWebhookUpdatedAuditLog : IChangesAuditLog<IWebhookAuditLogChanges>
-    { }
+    {
+        /// <summary>
+        ///     Gets the webhook this audit log is targeting.
+        ///     Returns <see langword="null"/> if the webhook was not provided with the audit log.
+        /// </summary>
+        IWebhook Webhook { get; }
+    }
 }

--- a/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Member/TransientBotAddedAuditLog.cs
+++ b/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Member/TransientBotAddedAuditLog.cs
@@ -1,9 +1,27 @@
-﻿using Disqord.Models;
+﻿using System;
+using Disqord.Models;
 
 namespace Disqord.AuditLogs
 {
     public class TransientBotAddedAuditLog : TransientAuditLog, IBotAddedAuditLog
     {
+        /// <inheritdoc/>
+        public IUser Bot
+        {
+            get
+            {
+                if (_bot == null)
+                {
+                    var bot = Array.Find(AuditLogJsonModel.Users, x => x.Id == TargetId);
+                    if (bot != null)
+                        _bot = new TransientUser(Client, bot);
+                }
+
+                return _bot;
+            }
+        }
+        private IUser _bot;
+
         public TransientBotAddedAuditLog(IClient client, Snowflake guildId, AuditLogJsonModel auditLogJsonModel, AuditLogEntryJsonModel model)
             : base(client, guildId, auditLogJsonModel, model)
         { }

--- a/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Member/TransientBotAddedAuditLog.cs
+++ b/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Member/TransientBotAddedAuditLog.cs
@@ -6,21 +6,21 @@ namespace Disqord.AuditLogs
     public class TransientBotAddedAuditLog : TransientAuditLog, IBotAddedAuditLog
     {
         /// <inheritdoc/>
-        public IUser User
+        public IUser Target
         {
             get
             {
-                if (_user == null)
+                if (_target == null)
                 {
                     var userModel = Array.Find(AuditLogJsonModel.Users, userModel => userModel.Id == TargetId);
                     if (userModel != null)
-                        _user = new TransientUser(Client, userModel);
+                        _target = new TransientUser(Client, userModel);
                 }
 
-                return _user;
+                return _target;
             }
         }
-        private IUser _user;
+        private IUser _target;
 
         public TransientBotAddedAuditLog(IClient client, Snowflake guildId, AuditLogJsonModel auditLogJsonModel, AuditLogEntryJsonModel model)
             : base(client, guildId, auditLogJsonModel, model)

--- a/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Member/TransientBotAddedAuditLog.cs
+++ b/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Member/TransientBotAddedAuditLog.cs
@@ -6,21 +6,21 @@ namespace Disqord.AuditLogs
     public class TransientBotAddedAuditLog : TransientAuditLog, IBotAddedAuditLog
     {
         /// <inheritdoc/>
-        public IUser Bot
+        public IUser User
         {
             get
             {
-                if (_bot == null)
+                if (_user == null)
                 {
-                    var bot = Array.Find(AuditLogJsonModel.Users, x => x.Id == TargetId);
-                    if (bot != null)
-                        _bot = new TransientUser(Client, bot);
+                    var userModel = Array.Find(AuditLogJsonModel.Users, userModel => userModel.Id == TargetId);
+                    if (userModel != null)
+                        _user = new TransientUser(Client, userModel);
                 }
 
-                return _bot;
+                return _user;
             }
         }
-        private IUser _bot;
+        private IUser _user;
 
         public TransientBotAddedAuditLog(IClient client, Snowflake guildId, AuditLogJsonModel auditLogJsonModel, AuditLogEntryJsonModel model)
             : base(client, guildId, auditLogJsonModel, model)

--- a/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Member/TransientMemberBannedAuditLog.cs
+++ b/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Member/TransientMemberBannedAuditLog.cs
@@ -1,9 +1,27 @@
-﻿using Disqord.Models;
+﻿using System;
+using Disqord.Models;
 
 namespace Disqord.AuditLogs
 {
     public class TransientMemberBannedAuditLog : TransientAuditLog, IMemberBannedAuditLog
     {
+        /// <inheritdoc/>
+        public IUser User
+        {
+            get
+            {
+                if (_user == null)
+                {
+                    var user = Array.Find(AuditLogJsonModel.Users, x => x.Id == TargetId);
+                    if (user != null)
+                        _user = new TransientUser(Client, user);
+                }
+
+                return _user;
+            }
+        }
+        private IUser _user;
+
         public TransientMemberBannedAuditLog(IClient client, Snowflake guildId, AuditLogJsonModel auditLogJsonModel, AuditLogEntryJsonModel model)
             : base(client, guildId, auditLogJsonModel, model)
         { }

--- a/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Member/TransientMemberBannedAuditLog.cs
+++ b/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Member/TransientMemberBannedAuditLog.cs
@@ -6,21 +6,21 @@ namespace Disqord.AuditLogs
     public class TransientMemberBannedAuditLog : TransientAuditLog, IMemberBannedAuditLog
     {
         /// <inheritdoc/>
-        public IUser User
+        public IUser Target
         {
             get
             {
-                if (_user == null)
+                if (_target == null)
                 {
                     var userModel = Array.Find(AuditLogJsonModel.Users, userModel => userModel.Id == TargetId);
                     if (userModel != null)
-                        _user = new TransientUser(Client, userModel);
+                        _target = new TransientUser(Client, userModel);
                 }
 
-                return _user;
+                return _target;
             }
         }
-        private IUser _user;
+        private IUser _target;
 
         public TransientMemberBannedAuditLog(IClient client, Snowflake guildId, AuditLogJsonModel auditLogJsonModel, AuditLogEntryJsonModel model)
             : base(client, guildId, auditLogJsonModel, model)

--- a/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Member/TransientMemberBannedAuditLog.cs
+++ b/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Member/TransientMemberBannedAuditLog.cs
@@ -12,9 +12,9 @@ namespace Disqord.AuditLogs
             {
                 if (_user == null)
                 {
-                    var user = Array.Find(AuditLogJsonModel.Users, x => x.Id == TargetId);
-                    if (user != null)
-                        _user = new TransientUser(Client, user);
+                    var userModel = Array.Find(AuditLogJsonModel.Users, userModel => userModel.Id == TargetId);
+                    if (userModel != null)
+                        _user = new TransientUser(Client, userModel);
                 }
 
                 return _user;

--- a/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Member/TransientMemberKickedAuditLog.cs
+++ b/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Member/TransientMemberKickedAuditLog.cs
@@ -12,9 +12,9 @@ namespace Disqord.AuditLogs
             {
                 if (_user == null)
                 {
-                    var user = Array.Find(AuditLogJsonModel.Users, x => x.Id == TargetId);
-                    if (user != null)
-                        _user = new TransientUser(Client, user);
+                    var userModel = Array.Find(AuditLogJsonModel.Users, userModel => userModel.Id == TargetId);
+                    if (userModel != null)
+                        _user = new TransientUser(Client, userModel);
                 }
 
                 return _user;

--- a/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Member/TransientMemberKickedAuditLog.cs
+++ b/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Member/TransientMemberKickedAuditLog.cs
@@ -1,9 +1,27 @@
-﻿using Disqord.Models;
+﻿using System;
+using Disqord.Models;
 
 namespace Disqord.AuditLogs
 {
     public class TransientMemberKickedAuditLog : TransientAuditLog, IMemberKickedAuditLog
     {
+        /// <inheritdoc/>
+        public IUser User
+        {
+            get
+            {
+                if (_user == null)
+                {
+                    var user = Array.Find(AuditLogJsonModel.Users, x => x.Id == TargetId);
+                    if (user != null)
+                        _user = new TransientUser(Client, user);
+                }
+
+                return _user;
+            }
+        }
+        private IUser _user;
+
         public TransientMemberKickedAuditLog(IClient client, Snowflake guildId, AuditLogJsonModel auditLogJsonModel, AuditLogEntryJsonModel model)
             : base(client, guildId, auditLogJsonModel, model)
         { }

--- a/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Member/TransientMemberKickedAuditLog.cs
+++ b/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Member/TransientMemberKickedAuditLog.cs
@@ -6,21 +6,21 @@ namespace Disqord.AuditLogs
     public class TransientMemberKickedAuditLog : TransientAuditLog, IMemberKickedAuditLog
     {
         /// <inheritdoc/>
-        public IUser User
+        public IUser Target
         {
             get
             {
-                if (_user == null)
+                if (_target == null)
                 {
                     var userModel = Array.Find(AuditLogJsonModel.Users, userModel => userModel.Id == TargetId);
                     if (userModel != null)
-                        _user = new TransientUser(Client, userModel);
+                        _target = new TransientUser(Client, userModel);
                 }
 
-                return _user;
+                return _target;
             }
         }
-        private IUser _user;
+        private IUser _target;
 
         public TransientMemberKickedAuditLog(IClient client, Snowflake guildId, AuditLogJsonModel auditLogJsonModel, AuditLogEntryJsonModel model)
             : base(client, guildId, auditLogJsonModel, model)

--- a/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Member/TransientMemberRolesUpdatedAuditLog.cs
+++ b/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Member/TransientMemberRolesUpdatedAuditLog.cs
@@ -15,21 +15,21 @@ namespace Disqord.AuditLogs
         public Optional<IReadOnlyDictionary<Snowflake, string>> RevokedRoles { get; }
 
         /// <inheritdoc/>
-        public IUser User
+        public IUser Target
         {
             get
             {
-                if (_user == null)
+                if (_target == null)
                 {
                     var userModel = Array.Find(AuditLogJsonModel.Users, userModel => userModel.Id == TargetId);
                     if (userModel != null)
-                        _user = new TransientUser(Client, userModel);
+                        _target = new TransientUser(Client, userModel);
                 }
 
-                return _user;
+                return _target;
             }
         }
-        private IUser _user;
+        private IUser _target;
 
         public TransientMemberRolesUpdatedAuditLog(IClient client, Snowflake guildId, AuditLogJsonModel auditLogJsonModel, AuditLogEntryJsonModel model)
             : base(client, guildId, auditLogJsonModel, model)

--- a/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Member/TransientMemberRolesUpdatedAuditLog.cs
+++ b/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Member/TransientMemberRolesUpdatedAuditLog.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Qommon.Collections;
 using Disqord.Models;
 using Microsoft.Extensions.Logging;
@@ -7,9 +8,28 @@ namespace Disqord.AuditLogs
 {
     public class TransientMemberRolesUpdatedAuditLog : TransientAuditLog, IMemberRolesUpdatedAuditLog
     {
+        /// <inheritdoc/>
         public Optional<IReadOnlyDictionary<Snowflake, string>> RolesGranted { get; }
 
+        /// <inheritdoc/>
         public Optional<IReadOnlyDictionary<Snowflake, string>> RolesRevoked { get; }
+
+        /// <inheritdoc/>
+        public IUser User
+        {
+            get
+            {
+                if (_user == null)
+                {
+                    var user = Array.Find(AuditLogJsonModel.Users, x => x.Id == TargetId);
+                    if (user != null)
+                        _user = new TransientUser(Client, user);
+                }
+
+                return _user;
+            }
+        }
+        private IUser _user;
 
         public TransientMemberRolesUpdatedAuditLog(IClient client, Snowflake guildId, AuditLogJsonModel auditLogJsonModel, AuditLogEntryJsonModel model)
             : base(client, guildId, auditLogJsonModel, model)

--- a/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Member/TransientMemberRolesUpdatedAuditLog.cs
+++ b/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Member/TransientMemberRolesUpdatedAuditLog.cs
@@ -9,10 +9,10 @@ namespace Disqord.AuditLogs
     public class TransientMemberRolesUpdatedAuditLog : TransientAuditLog, IMemberRolesUpdatedAuditLog
     {
         /// <inheritdoc/>
-        public Optional<IReadOnlyDictionary<Snowflake, string>> RolesGranted { get; }
+        public Optional<IReadOnlyDictionary<Snowflake, string>> GrantedRoles { get; }
 
         /// <inheritdoc/>
-        public Optional<IReadOnlyDictionary<Snowflake, string>> RolesRevoked { get; }
+        public Optional<IReadOnlyDictionary<Snowflake, string>> RevokedRoles { get; }
 
         /// <inheritdoc/>
         public IUser User
@@ -21,9 +21,9 @@ namespace Disqord.AuditLogs
             {
                 if (_user == null)
                 {
-                    var user = Array.Find(AuditLogJsonModel.Users, x => x.Id == TargetId);
-                    if (user != null)
-                        _user = new TransientUser(Client, user);
+                    var userModel = Array.Find(AuditLogJsonModel.Users, userModel => userModel.Id == TargetId);
+                    if (userModel != null)
+                        _user = new TransientUser(Client, userModel);
                 }
 
                 return _user;
@@ -41,7 +41,7 @@ namespace Disqord.AuditLogs
                 {
                     case "$add":
                     {
-                        RolesGranted = Optional.Convert(change.NewValue, x =>
+                        GrantedRoles = Optional.Convert(change.NewValue, x =>
                         {
                             var models = x.ToType<RoleJsonModel[]>();
                             return models.ToReadOnlyDictionary(x => x.Id, x => x.Name);
@@ -50,7 +50,7 @@ namespace Disqord.AuditLogs
                     }
                     case "$remove":
                     {
-                        RolesRevoked = Optional.Convert(change.NewValue, x =>
+                        RevokedRoles = Optional.Convert(change.NewValue, x =>
                         {
                             var models = x.ToType<RoleJsonModel[]>();
                             return models.ToReadOnlyDictionary(x => x.Id, x => x.Name);

--- a/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Member/TransientMemberUnbannedAuditLog.cs
+++ b/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Member/TransientMemberUnbannedAuditLog.cs
@@ -1,9 +1,27 @@
-﻿using Disqord.Models;
+﻿using System;
+using Disqord.Models;
 
 namespace Disqord.AuditLogs
 {
     public class TransientMemberUnbannedAuditLog : TransientAuditLog, IMemberUnbannedAuditLog
     {
+        /// <inheritdoc/>
+        public IUser User
+        {
+            get
+            {
+                if (_user == null)
+                {
+                    var user = Array.Find(AuditLogJsonModel.Users, x => x.Id == TargetId);
+                    if (user != null)
+                        _user = new TransientUser(Client, user);
+                }
+
+                return _user;
+            }
+        }
+        private IUser _user;
+
         public TransientMemberUnbannedAuditLog(IClient client, Snowflake guildId, AuditLogJsonModel auditLogJsonModel, AuditLogEntryJsonModel model)
             : base(client, guildId, auditLogJsonModel, model)
         { }

--- a/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Member/TransientMemberUnbannedAuditLog.cs
+++ b/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Member/TransientMemberUnbannedAuditLog.cs
@@ -12,9 +12,9 @@ namespace Disqord.AuditLogs
             {
                 if (_user == null)
                 {
-                    var user = Array.Find(AuditLogJsonModel.Users, x => x.Id == TargetId);
-                    if (user != null)
-                        _user = new TransientUser(Client, user);
+                    var userModel = Array.Find(AuditLogJsonModel.Users, userModel => userModel.Id == TargetId);
+                    if (userModel != null)
+                        _user = new TransientUser(Client, userModel);
                 }
 
                 return _user;

--- a/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Member/TransientMemberUnbannedAuditLog.cs
+++ b/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Member/TransientMemberUnbannedAuditLog.cs
@@ -6,21 +6,21 @@ namespace Disqord.AuditLogs
     public class TransientMemberUnbannedAuditLog : TransientAuditLog, IMemberUnbannedAuditLog
     {
         /// <inheritdoc/>
-        public IUser User
+        public IUser Target
         {
             get
             {
-                if (_user == null)
+                if (_target == null)
                 {
                     var userModel = Array.Find(AuditLogJsonModel.Users, userModel => userModel.Id == TargetId);
                     if (userModel != null)
-                        _user = new TransientUser(Client, userModel);
+                        _target = new TransientUser(Client, userModel);
                 }
 
-                return _user;
+                return _target;
             }
         }
-        private IUser _user;
+        private IUser _target;
 
         public TransientMemberUnbannedAuditLog(IClient client, Snowflake guildId, AuditLogJsonModel auditLogJsonModel, AuditLogEntryJsonModel model)
             : base(client, guildId, auditLogJsonModel, model)

--- a/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Member/TransientMemberUpdatedAuditLog.cs
+++ b/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Member/TransientMemberUpdatedAuditLog.cs
@@ -8,21 +8,21 @@ namespace Disqord.AuditLogs
         public override IMemberAuditLogChanges Changes { get; }
 
         /// <inheritdoc/>
-        public IUser User
+        public IUser Target
         {
             get
             {
-                if (_user == null)
+                if (_target == null)
                 {
                     var userModel = Array.Find(AuditLogJsonModel.Users, userModel => userModel.Id == TargetId);
                     if (userModel != null)
-                        _user = new TransientUser(Client, userModel);
+                        _target = new TransientUser(Client, userModel);
                 }
 
-                return _user;
+                return _target;
             }
         }
-        private IUser _user;
+        private IUser _target;
 
         public TransientMemberUpdatedAuditLog(IClient client, Snowflake guildId, AuditLogJsonModel auditLogJsonModel, AuditLogEntryJsonModel model)
             : base(client, guildId, auditLogJsonModel, model)

--- a/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Member/TransientMemberUpdatedAuditLog.cs
+++ b/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Member/TransientMemberUpdatedAuditLog.cs
@@ -1,10 +1,29 @@
-﻿using Disqord.Models;
+﻿using System;
+using Disqord.Models;
 
 namespace Disqord.AuditLogs
 {
     public class TransientMemberUpdatedAuditLog : TransientChangesAuditLog<IMemberAuditLogChanges>, IMemberUpdatedAuditLog
     {
+        /// <inheritdoc/>
         public override IMemberAuditLogChanges Changes { get; }
+
+        /// <inheritdoc/>
+        public IUser User
+        {
+            get
+            {
+                if (_user == null)
+                {
+                    var user = Array.Find(AuditLogJsonModel.Users, x => x.Id == TargetId);
+                    if (user != null)
+                        _user = new TransientUser(Client, user);
+                }
+
+                return _user;
+            }
+        }
+        private IUser _user;
 
         public TransientMemberUpdatedAuditLog(IClient client, Snowflake guildId, AuditLogJsonModel auditLogJsonModel, AuditLogEntryJsonModel model)
             : base(client, guildId, auditLogJsonModel, model)

--- a/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Member/TransientMemberUpdatedAuditLog.cs
+++ b/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Member/TransientMemberUpdatedAuditLog.cs
@@ -14,9 +14,9 @@ namespace Disqord.AuditLogs
             {
                 if (_user == null)
                 {
-                    var user = Array.Find(AuditLogJsonModel.Users, x => x.Id == TargetId);
-                    if (user != null)
-                        _user = new TransientUser(Client, user);
+                    var userModel = Array.Find(AuditLogJsonModel.Users, userModel => userModel.Id == TargetId);
+                    if (userModel != null)
+                        _user = new TransientUser(Client, userModel);
                 }
 
                 return _user;

--- a/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Member/TransientMemberUpdatedAuditLog.cs
+++ b/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Member/TransientMemberUpdatedAuditLog.cs
@@ -5,7 +5,6 @@ namespace Disqord.AuditLogs
 {
     public class TransientMemberUpdatedAuditLog : TransientChangesAuditLog<IMemberAuditLogChanges>, IMemberUpdatedAuditLog
     {
-        /// <inheritdoc/>
         public override IMemberAuditLogChanges Changes { get; }
 
         /// <inheritdoc/>

--- a/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Member/TransientMembersDisconnectedAuditLog.cs
+++ b/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Member/TransientMembersDisconnectedAuditLog.cs
@@ -4,6 +4,7 @@ namespace Disqord.AuditLogs
 {
     public class TransientMembersDisconnectedAuditLog : TransientAuditLog, IMembersDisconnectedAuditLog
     {
+        /// <inheritdoc/>
         public int Count => Model.Options.Value.Count.Value;
 
         public TransientMembersDisconnectedAuditLog(IClient client, Snowflake guildId, AuditLogJsonModel auditLogJsonModel, AuditLogEntryJsonModel model)

--- a/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Member/TransientMembersMovedAuditLog.cs
+++ b/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Member/TransientMembersMovedAuditLog.cs
@@ -4,8 +4,10 @@ namespace Disqord.AuditLogs
 {
     public class TransientMembersMovedAuditLog : TransientAuditLog, IMembersMovedAuditLog
     {
+        /// <inheritdoc/>
         public Snowflake ChannelId => Model.Options.Value.ChannelId.Value;
 
+        /// <inheritdoc/>
         public int Count => Model.Options.Value.Count.Value;
 
         public TransientMembersMovedAuditLog(IClient client, Snowflake guildId, AuditLogJsonModel auditLogJsonModel, AuditLogEntryJsonModel model)

--- a/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Member/TransientMembersPrunedAuditLog.cs
+++ b/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Member/TransientMembersPrunedAuditLog.cs
@@ -4,8 +4,10 @@ namespace Disqord.AuditLogs
 {
     public class TransientMembersPrunedAuditLog : TransientAuditLog, IMembersPrunedAuditLog
     {
+        /// <inheritdoc/>
         public int Days => Model.Options.Value.DeleteMemberDays.Value;
 
+        /// <inheritdoc/>
         public int Count => Model.Options.Value.Count.Value;
 
         public TransientMembersPrunedAuditLog(IClient client, Snowflake guildId, AuditLogJsonModel auditLogJsonModel, AuditLogEntryJsonModel model)

--- a/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Message/TransientMessagePinnedAuditLog.cs
+++ b/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Message/TransientMessagePinnedAuditLog.cs
@@ -4,8 +4,10 @@ namespace Disqord.AuditLogs
 {
     public class TransientMessagePinnedAuditLog : TransientAuditLog, IMessagePinnedAuditLog
     {
+        /// <inheritdoc/>
         public Snowflake ChannelId => Model.Options.Value.ChannelId.Value;
 
+        /// <inheritdoc/>
         public Snowflake MessageId => Model.Options.Value.MessageId.Value;
 
         public TransientMessagePinnedAuditLog(IClient client, Snowflake guildId, AuditLogJsonModel auditLogJsonModel, AuditLogEntryJsonModel model)

--- a/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Message/TransientMessageUnpinnedAuditLog.cs
+++ b/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Message/TransientMessageUnpinnedAuditLog.cs
@@ -4,8 +4,10 @@ namespace Disqord.AuditLogs
 {
     public class TransientMessageUnpinnedAuditLog : TransientAuditLog, IMessageUnpinnedAuditLog
     {
+        /// <inheritdoc/>
         public Snowflake ChannelId => Model.Options.Value.ChannelId.Value;
 
+        /// <inheritdoc/>
         public Snowflake MessageId => Model.Options.Value.MessageId.Value;
 
         public TransientMessageUnpinnedAuditLog(IClient client, Snowflake guildId, AuditLogJsonModel auditLogJsonModel, AuditLogEntryJsonModel model)

--- a/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Message/TransientMessagesBulkDeletedAuditLog.cs
+++ b/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Message/TransientMessagesBulkDeletedAuditLog.cs
@@ -4,8 +4,10 @@ namespace Disqord.AuditLogs
 {
     public class TransientMessagesBulkDeletedAuditLog : TransientAuditLog, IMessagesBulkDeletedAuditLog
     {
+        /// <inheritdoc/>
         public Snowflake ChannelId => Model.Options.Value.ChannelId.Value;
 
+        /// <inheritdoc/>
         public int Count => Model.Options.Value.Count.Value;
 
         public TransientMessagesBulkDeletedAuditLog(IClient client, Snowflake guildId, AuditLogJsonModel auditLogJsonModel, AuditLogEntryJsonModel model)

--- a/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Message/TransientMessagesDeletedAuditLog.cs
+++ b/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Message/TransientMessagesDeletedAuditLog.cs
@@ -4,8 +4,10 @@ namespace Disqord.AuditLogs
 {
     public class TransientMessagesDeletedAuditLog : TransientAuditLog, IMessagesDeletedAuditLog
     {
+        /// <inheritdoc/>
         public Snowflake ChannelId => Model.Options.Value.ChannelId.Value;
 
+        /// <inheritdoc/>
         public int Count => Model.Options.Value.Count.Value;
 
         public TransientMessagesDeletedAuditLog(IClient client, Snowflake guildId, AuditLogJsonModel auditLogJsonModel, AuditLogEntryJsonModel model)

--- a/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Threads/TransientThreadCreatedAuditLog.cs
+++ b/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Threads/TransientThreadCreatedAuditLog.cs
@@ -5,7 +5,6 @@ namespace Disqord.AuditLogs
 {
     public class TransientThreadCreatedAuditLog : TransientDataAuditLog<IThreadAuditLogData>, IThreadCreatedAuditLog
     {
-        /// <inheritdoc/>
         public override IThreadAuditLogData Data { get; }
 
         /// <inheritdoc/>

--- a/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Threads/TransientThreadCreatedAuditLog.cs
+++ b/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Threads/TransientThreadCreatedAuditLog.cs
@@ -8,21 +8,21 @@ namespace Disqord.AuditLogs
         public override IThreadAuditLogData Data { get; }
 
         /// <inheritdoc/>
-        public IThreadChannel Thread
+        public IThreadChannel Target
         {
             get
             {
-                if (_thread == null)
+                if (_target == null)
                 {
                     var threadModel = Array.Find(AuditLogJsonModel.Threads, threadModel => threadModel.Id == TargetId);
                     if (threadModel != null)
-                        _thread = new TransientThreadChannel(Client, threadModel);
+                        _target = new TransientThreadChannel(Client, threadModel);
                 }
 
-                return _thread;
+                return _target;
             }
         }
-        private IThreadChannel _thread;
+        private IThreadChannel _target;
 
         public TransientThreadCreatedAuditLog(IClient client, Snowflake guildId, AuditLogJsonModel auditLogJsonModel, AuditLogEntryJsonModel model)
             : base(client, guildId, auditLogJsonModel, model)

--- a/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Threads/TransientThreadCreatedAuditLog.cs
+++ b/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Threads/TransientThreadCreatedAuditLog.cs
@@ -14,9 +14,9 @@ namespace Disqord.AuditLogs
             {
                 if (_thread == null)
                 {
-                    var thread = Array.Find(AuditLogJsonModel.Threads, x => x.Id == TargetId);
-                    if (thread != null)
-                        _thread = new TransientThreadChannel(Client, thread);
+                    var threadModel = Array.Find(AuditLogJsonModel.Threads, threadModel => threadModel.Id == TargetId);
+                    if (threadModel != null)
+                        _thread = new TransientThreadChannel(Client, threadModel);
                 }
 
                 return _thread;

--- a/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Threads/TransientThreadCreatedAuditLog.cs
+++ b/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Threads/TransientThreadCreatedAuditLog.cs
@@ -1,10 +1,29 @@
+using System;
 using Disqord.Models;
 
 namespace Disqord.AuditLogs
 {
     public class TransientThreadCreatedAuditLog : TransientDataAuditLog<IThreadAuditLogData>, IThreadCreatedAuditLog
     {
+        /// <inheritdoc/>
         public override IThreadAuditLogData Data { get; }
+
+        /// <inheritdoc/>
+        public IThreadChannel Thread
+        {
+            get
+            {
+                if (_thread == null)
+                {
+                    var thread = Array.Find(AuditLogJsonModel.Threads, x => x.Id == TargetId);
+                    if (thread != null)
+                        _thread = new TransientThreadChannel(Client, thread);
+                }
+
+                return _thread;
+            }
+        }
+        private IThreadChannel _thread;
 
         public TransientThreadCreatedAuditLog(IClient client, Snowflake guildId, AuditLogJsonModel auditLogJsonModel, AuditLogEntryJsonModel model)
             : base(client, guildId, auditLogJsonModel, model)

--- a/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Threads/TransientThreadDeletedAuditLog.cs
+++ b/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Threads/TransientThreadDeletedAuditLog.cs
@@ -4,7 +4,6 @@ namespace Disqord.AuditLogs
 {
     public class TransientThreadDeletedAuditLog : TransientDataAuditLog<IThreadAuditLogData>, IThreadDeletedAuditLog
     {
-        /// <inheritdoc/>
         public override IThreadAuditLogData Data { get; }
 
         public TransientThreadDeletedAuditLog(IClient client, Snowflake guildId, AuditLogJsonModel auditLogJsonModel, AuditLogEntryJsonModel model)

--- a/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Threads/TransientThreadDeletedAuditLog.cs
+++ b/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Threads/TransientThreadDeletedAuditLog.cs
@@ -4,6 +4,7 @@ namespace Disqord.AuditLogs
 {
     public class TransientThreadDeletedAuditLog : TransientDataAuditLog<IThreadAuditLogData>, IThreadDeletedAuditLog
     {
+        /// <inheritdoc/>
         public override IThreadAuditLogData Data { get; }
 
         public TransientThreadDeletedAuditLog(IClient client, Snowflake guildId, AuditLogJsonModel auditLogJsonModel, AuditLogEntryJsonModel model)

--- a/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Threads/TransientThreadUpdatedAuditLog.cs
+++ b/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Threads/TransientThreadUpdatedAuditLog.cs
@@ -5,7 +5,6 @@ namespace Disqord.AuditLogs
 {
     public class TransientThreadUpdatedAuditLog : TransientChangesAuditLog<IThreadAuditLogChanges>, IThreadUpdatedAuditLog
     {
-        /// <inheritdoc/>
         public override IThreadAuditLogChanges Changes { get; }
 
         /// <inheritdoc/>

--- a/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Threads/TransientThreadUpdatedAuditLog.cs
+++ b/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Threads/TransientThreadUpdatedAuditLog.cs
@@ -1,10 +1,29 @@
+using System;
 using Disqord.Models;
 
 namespace Disqord.AuditLogs
 {
     public class TransientThreadUpdatedAuditLog : TransientChangesAuditLog<IThreadAuditLogChanges>, IThreadUpdatedAuditLog
     {
+        /// <inheritdoc/>
         public override IThreadAuditLogChanges Changes { get; }
+
+        /// <inheritdoc/>
+        public IThreadChannel Thread
+        {
+            get
+            {
+                if (_thread == null)
+                {
+                    var thread = Array.Find(AuditLogJsonModel.Threads, x => x.Id == TargetId);
+                    if (thread != null)
+                        _thread = new TransientThreadChannel(Client, thread);
+                }
+
+                return _thread;
+            }
+        }
+        private IThreadChannel _thread;
 
         public TransientThreadUpdatedAuditLog(IClient client, Snowflake guildId, AuditLogJsonModel auditLogJsonModel, AuditLogEntryJsonModel model)
             : base(client, guildId, auditLogJsonModel, model)

--- a/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Threads/TransientThreadUpdatedAuditLog.cs
+++ b/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Threads/TransientThreadUpdatedAuditLog.cs
@@ -14,9 +14,9 @@ namespace Disqord.AuditLogs
             {
                 if (_thread == null)
                 {
-                    var thread = Array.Find(AuditLogJsonModel.Threads, x => x.Id == TargetId);
-                    if (thread != null)
-                        _thread = new TransientThreadChannel(Client, thread);
+                    var threadModel = Array.Find(AuditLogJsonModel.Threads, threadModel => threadModel.Id == TargetId);
+                    if (threadModel != null)
+                        _thread = new TransientThreadChannel(Client, threadModel);
                 }
 
                 return _thread;

--- a/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Threads/TransientThreadUpdatedAuditLog.cs
+++ b/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Threads/TransientThreadUpdatedAuditLog.cs
@@ -8,21 +8,21 @@ namespace Disqord.AuditLogs
         public override IThreadAuditLogChanges Changes { get; }
 
         /// <inheritdoc/>
-        public IThreadChannel Thread
+        public IThreadChannel Target
         {
             get
             {
-                if (_thread == null)
+                if (_target == null)
                 {
                     var threadModel = Array.Find(AuditLogJsonModel.Threads, threadModel => threadModel.Id == TargetId);
                     if (threadModel != null)
-                        _thread = new TransientThreadChannel(Client, threadModel);
+                        _target = new TransientThreadChannel(Client, threadModel);
                 }
 
-                return _thread;
+                return _target;
             }
         }
-        private IThreadChannel _thread;
+        private IThreadChannel _target;
 
         public TransientThreadUpdatedAuditLog(IClient client, Snowflake guildId, AuditLogJsonModel auditLogJsonModel, AuditLogEntryJsonModel model)
             : base(client, guildId, auditLogJsonModel, model)

--- a/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/TransientAuditLog.cs
+++ b/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/TransientAuditLog.cs
@@ -24,9 +24,9 @@ namespace Disqord.AuditLogs
             {
                 if (_actor == null)
                 {
-                    var actor = Array.Find(AuditLogJsonModel.Users, x => x.Id == ActorId);
-                    if (actor != null)
-                        _actor = new TransientUser(Client, actor);
+                    var userModel = Array.Find(AuditLogJsonModel.Users, userModel => userModel.Id == ActorId);
+                    if (userModel != null)
+                        _actor = new TransientUser(Client, userModel);
                 }
 
                 return _actor;

--- a/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/TransientAuditLog.cs
+++ b/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/TransientAuditLog.cs
@@ -11,26 +11,20 @@ namespace Disqord.AuditLogs
         /// <inheritdoc/>
         public Snowflake GuildId { get; }
 
-        /// <summary>
-        ///     Gets the ID of the entity this audit log is targeting.
-        /// </summary>
+        /// <inheritdoc/>
         public Snowflake? TargetId => Model.TargetId;
 
-        /// <summary>
-        ///     Gets the ID of the user this audit log was actioned by.
-        /// </summary>
+        /// <inheritdoc/>
         public Snowflake? ActorId => Model.UserId;
 
-        /// <summary>
-        ///     Gets the optional user this audit log was actioned by.
-        /// </summary>
+        /// <inheritdoc/>
         public IUser Actor
         {
             get
             {
                 if (_actor == null)
                 {
-                    var actor = Array.Find(_auditLogJsonModel.Users, x => x.Id == ActorId);
+                    var actor = Array.Find(AuditLogJsonModel.Users, x => x.Id == ActorId);
                     if (actor != null)
                         _actor = new TransientUser(Client, actor);
                 }
@@ -40,17 +34,15 @@ namespace Disqord.AuditLogs
         }
         private IUser _actor;
 
-        /// <summary>
-        ///     Gets the reason of this audit log.
-        /// </summary>
+        /// <inheritdoc/>
         public string Reason => Model.Reason.GetValueOrDefault();
 
-        private readonly AuditLogJsonModel _auditLogJsonModel;
+        protected readonly AuditLogJsonModel AuditLogJsonModel;
 
         public TransientAuditLog(IClient client, Snowflake guildId, AuditLogJsonModel auditLogJsonModel, AuditLogEntryJsonModel model)
             : base(client, model)
         {
-            _auditLogJsonModel = auditLogJsonModel;
+            AuditLogJsonModel = auditLogJsonModel;
             GuildId = guildId;
         }
 

--- a/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Webhook/TransientWebhookCreatedAuditLog.cs
+++ b/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Webhook/TransientWebhookCreatedAuditLog.cs
@@ -1,10 +1,29 @@
-﻿using Disqord.Models;
+﻿using System;
+using Disqord.Models;
 
 namespace Disqord.AuditLogs
 {
     public class TransientWebhookCreatedAuditLog : TransientDataAuditLog<IWebhookAuditLogData>, IWebhookCreatedAuditLog
     {
+        /// <inheritdoc/>
         public override IWebhookAuditLogData Data { get; }
+
+        /// <inheritdoc/>
+        public IWebhook Webhook
+        {
+            get
+            {
+                if (_webhook == null)
+                {
+                    var webhook = Array.Find(AuditLogJsonModel.Webhooks, x => x.Id == TargetId);
+                    if (webhook != null)
+                        _webhook = new TransientWebhook(Client, webhook);
+                }
+
+                return _webhook;
+            }
+        }
+        private IWebhook _webhook;
 
         public TransientWebhookCreatedAuditLog(IClient client, Snowflake guildId, AuditLogJsonModel auditLogJsonModel, AuditLogEntryJsonModel model)
             : base(client, guildId, auditLogJsonModel, model)

--- a/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Webhook/TransientWebhookCreatedAuditLog.cs
+++ b/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Webhook/TransientWebhookCreatedAuditLog.cs
@@ -8,21 +8,21 @@ namespace Disqord.AuditLogs
         public override IWebhookAuditLogData Data { get; }
 
         /// <inheritdoc/>
-        public IWebhook Webhook
+        public IWebhook Target
         {
             get
             {
-                if (_webhook == null)
+                if (_target == null)
                 {
                     var webhookModel = Array.Find(AuditLogJsonModel.Webhooks, webhookModel => webhookModel.Id == TargetId);
                     if (webhookModel != null)
-                        _webhook = new TransientWebhook(Client, webhookModel);
+                        _target = new TransientWebhook(Client, webhookModel);
                 }
 
-                return _webhook;
+                return _target;
             }
         }
-        private IWebhook _webhook;
+        private IWebhook _target;
 
         public TransientWebhookCreatedAuditLog(IClient client, Snowflake guildId, AuditLogJsonModel auditLogJsonModel, AuditLogEntryJsonModel model)
             : base(client, guildId, auditLogJsonModel, model)

--- a/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Webhook/TransientWebhookCreatedAuditLog.cs
+++ b/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Webhook/TransientWebhookCreatedAuditLog.cs
@@ -14,9 +14,9 @@ namespace Disqord.AuditLogs
             {
                 if (_webhook == null)
                 {
-                    var webhook = Array.Find(AuditLogJsonModel.Webhooks, x => x.Id == TargetId);
-                    if (webhook != null)
-                        _webhook = new TransientWebhook(Client, webhook);
+                    var webhookModel = Array.Find(AuditLogJsonModel.Webhooks, webhookModel => webhookModel.Id == TargetId);
+                    if (webhookModel != null)
+                        _webhook = new TransientWebhook(Client, webhookModel);
                 }
 
                 return _webhook;

--- a/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Webhook/TransientWebhookCreatedAuditLog.cs
+++ b/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Webhook/TransientWebhookCreatedAuditLog.cs
@@ -5,7 +5,6 @@ namespace Disqord.AuditLogs
 {
     public class TransientWebhookCreatedAuditLog : TransientDataAuditLog<IWebhookAuditLogData>, IWebhookCreatedAuditLog
     {
-        /// <inheritdoc/>
         public override IWebhookAuditLogData Data { get; }
 
         /// <inheritdoc/>

--- a/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Webhook/TransientWebhookDeletedAuditLog.cs
+++ b/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Webhook/TransientWebhookDeletedAuditLog.cs
@@ -4,7 +4,6 @@ namespace Disqord.AuditLogs
 {
     public class TransientWebhookDeletedAuditLog : TransientDataAuditLog<IWebhookAuditLogData>, IWebhookDeletedAuditLog
     {
-        /// <inheritdoc/>
         public override IWebhookAuditLogData Data { get; }
 
         public TransientWebhookDeletedAuditLog(IClient client, Snowflake guildId, AuditLogJsonModel auditLogJsonModel, AuditLogEntryJsonModel model)

--- a/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Webhook/TransientWebhookDeletedAuditLog.cs
+++ b/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Webhook/TransientWebhookDeletedAuditLog.cs
@@ -4,6 +4,7 @@ namespace Disqord.AuditLogs
 {
     public class TransientWebhookDeletedAuditLog : TransientDataAuditLog<IWebhookAuditLogData>, IWebhookDeletedAuditLog
     {
+        /// <inheritdoc/>
         public override IWebhookAuditLogData Data { get; }
 
         public TransientWebhookDeletedAuditLog(IClient client, Snowflake guildId, AuditLogJsonModel auditLogJsonModel, AuditLogEntryJsonModel model)

--- a/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Webhook/TransientWebhookUpdatedAuditLog.cs
+++ b/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Webhook/TransientWebhookUpdatedAuditLog.cs
@@ -1,10 +1,29 @@
-﻿using Disqord.Models;
+﻿using System;
+using Disqord.Models;
 
 namespace Disqord.AuditLogs
 {
     public class TransientWebhookUpdatedAuditLog : TransientChangesAuditLog<IWebhookAuditLogChanges>, IWebhookUpdatedAuditLog
     {
+        /// <inheritdoc/>
         public override IWebhookAuditLogChanges Changes { get; }
+
+        /// <inheritdoc/>
+        public IWebhook Webhook
+        {
+            get
+            {
+                if (_webhook == null)
+                {
+                    var webhook = Array.Find(AuditLogJsonModel.Webhooks, x => x.Id == TargetId);
+                    if (webhook != null)
+                        _webhook = new TransientWebhook(Client, webhook);
+                }
+
+                return _webhook;
+            }
+        }
+        private IWebhook _webhook;
 
         public TransientWebhookUpdatedAuditLog(IClient client, Snowflake guildId, AuditLogJsonModel auditLogJsonModel, AuditLogEntryJsonModel model)
             : base(client, guildId, auditLogJsonModel, model)

--- a/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Webhook/TransientWebhookUpdatedAuditLog.cs
+++ b/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Webhook/TransientWebhookUpdatedAuditLog.cs
@@ -5,7 +5,6 @@ namespace Disqord.AuditLogs
 {
     public class TransientWebhookUpdatedAuditLog : TransientChangesAuditLog<IWebhookAuditLogChanges>, IWebhookUpdatedAuditLog
     {
-        /// <inheritdoc/>
         public override IWebhookAuditLogChanges Changes { get; }
 
         /// <inheritdoc/>

--- a/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Webhook/TransientWebhookUpdatedAuditLog.cs
+++ b/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Webhook/TransientWebhookUpdatedAuditLog.cs
@@ -14,9 +14,9 @@ namespace Disqord.AuditLogs
             {
                 if (_webhook == null)
                 {
-                    var webhook = Array.Find(AuditLogJsonModel.Webhooks, x => x.Id == TargetId);
-                    if (webhook != null)
-                        _webhook = new TransientWebhook(Client, webhook);
+                    var webhookModel = Array.Find(AuditLogJsonModel.Webhooks, webhookModel => webhookModel.Id == TargetId);
+                    if (webhookModel != null)
+                        _webhook = new TransientWebhook(Client, webhookModel);
                 }
 
                 return _webhook;

--- a/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Webhook/TransientWebhookUpdatedAuditLog.cs
+++ b/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/Webhook/TransientWebhookUpdatedAuditLog.cs
@@ -8,21 +8,21 @@ namespace Disqord.AuditLogs
         public override IWebhookAuditLogChanges Changes { get; }
 
         /// <inheritdoc/>
-        public IWebhook Webhook
+        public IWebhook Target
         {
             get
             {
-                if (_webhook == null)
+                if (_target == null)
                 {
                     var webhookModel = Array.Find(AuditLogJsonModel.Webhooks, webhookModel => webhookModel.Id == TargetId);
                     if (webhookModel != null)
-                        _webhook = new TransientWebhook(Client, webhookModel);
+                        _target = new TransientWebhook(Client, webhookModel);
                 }
 
-                return _webhook;
+                return _target;
             }
         }
-        private IWebhook _webhook;
+        private IWebhook _target;
 
         public TransientWebhookUpdatedAuditLog(IClient client, Snowflake guildId, AuditLogJsonModel auditLogJsonModel, AuditLogEntryJsonModel model)
             : base(client, guildId, auditLogJsonModel, model)


### PR DESCRIPTION
## Description

- Added `User` property to `IBotAddedAuditLog`, `IMemberBannedAuditLog`, `IMemberKickedAuditLog`, `IMemberRolesUpdatedAuditLog`, `IMemberUnbannedAuditLog`, `IMemberUpdatedAuditLog`.
- Added `Thread` property to `IThreadCreatedAuditLog`, `IThreadUpdatedAuditLog`.
- Added `Webhook` property to `IWebhookCreatedAuditLog`, `IWebhookUpdatedAuditLog`.
- Improved audit logs documentation in general.

## Checklist

- [x] I discussed this PR with the maintainer(s) prior to opening it.
- [x] I read the [contributing guidelines](https://github.com/Quahu/Disqord/blob/master/.github/CONTRIBUTING.md).
- [x] I tested the changes in this PR.
