### PR TITLE
Updated max CDN image size

### DIFF
--- a/src/Disqord.Core/Discord/Cdn/Discord.Cdn.cs
+++ b/src/Disqord.Core/Discord/Cdn/Discord.Cdn.cs
@@ -122,8 +122,8 @@ namespace Disqord
                 if (size != null)
                 {
                     var value = size.Value;
-                    if (value < 16 || value > 2048 || (value & -value) != value)
-                        Throw.ArgumentOutOfRangeException(nameof(size), "Size must be a power of 2 between 16 and 2048.");
+                    if (value < 16 || value > 4096 || (value & -value) != value)
+                        Throw.ArgumentOutOfRangeException(nameof(size), "Size must be a power of 2 between 16 and 4096.");
                 }
 
                 if (format == CdnAssetFormat.Automatic)


### PR DESCRIPTION
## Description

The CDN supports a 4096px image size now, probably added to support banners.


## Checklist

[//]: # "Put an x in [ ] to check the checkbox, e.g. [x]"

- [x] I discussed this PR with the maintainer(s) prior to opening it.
- [x] I read the [contributing guidelines](https://github.com/Quahu/Disqord/blob/master/.github/CONTRIBUTING.md).
- [x] I tested the changes in this PR.
