### PR TITLE
Implemented oauth2 method to fetch current guild member (guilds.members.read)

### DIFF
--- a/src/Disqord.OAuth2/Extensions/BearerClientExtensions.cs
+++ b/src/Disqord.OAuth2/Extensions/BearerClientExtensions.cs
@@ -87,6 +87,25 @@ namespace Disqord.OAuth2
         }
 
         /// <summary>
+        ///     Fetches the current member from a guild tied to this bearer token.
+        /// </summary>
+        /// <param name="client"> The bearer client. </param>
+        /// <param name="guildId"> The ID of the guild to fetch the member from. </param>
+        /// <param name="options"> The optional request options. </param>
+        /// <param name="cancellationToken"> The cancellation token to observe. </param>
+        /// <returns>
+        ///     A <see cref="Task{TResult}"/> representing the asynchronous request
+        ///     that wraps the returned <see cref="IMember"/>.
+        /// </returns>
+        public static async Task<IMember> FetchCurrentGuildMemberAsync(this IBearerClient client,
+            Snowflake guildId,
+            IRestRequestOptions options = null, CancellationToken cancellationToken = default)
+        {
+            var model = await client.RestClient.ApiClient.FetchCurrentGuildMemberAsync(guildId, options, cancellationToken).ConfigureAwait(false);
+            return new TransientMember(client.RestClient, guildId, model);
+        }
+
+        /// <summary>
         ///     Fetches the connections of the user tied to this bearer token.
         /// </summary>
         /// <param name="client"> The bearer client. </param>

--- a/src/Disqord.Rest.Api/Methods/RestApiClientExtensions.User.cs
+++ b/src/Disqord.Rest.Api/Methods/RestApiClientExtensions.User.cs
@@ -69,6 +69,14 @@ namespace Disqord.Rest.Api
             return client.ExecuteAsync<GuildJsonModel[]>(route, null, options, cancellationToken);
         }
 
+        public static Task<MemberJsonModel> FetchCurrentGuildMemberAsync(this IRestApiClient client,
+            Snowflake guildId,
+            IRestRequestOptions options = null, CancellationToken cancellationToken = default)
+        {
+            var route = Format(Route.User.GetCurrentGuildMember, guildId);
+            return client.ExecuteAsync<MemberJsonModel>(route, null, options, cancellationToken);
+        }
+
         public static Task LeaveGuildAsync(this IRestApiClient client,
             Snowflake guildId,
             IRestRequestOptions options = null, CancellationToken cancellationToken = default)

--- a/src/Disqord.Rest.Api/Routing/Route.Static.cs
+++ b/src/Disqord.Rest.Api/Routing/Route.Static.cs
@@ -256,6 +256,8 @@ namespace Disqord.Rest.Api
 
             public static readonly Route GetGuilds = Get("users/@me/guilds");
 
+            public static readonly Route GetCurrentGuildMember = Get("users/@me/guilds/{0:guild_id}/member");
+
             public static readonly Route LeaveGuild = Delete("users/@me/guilds/{0:guild_id}");
 
             public static readonly Route CreateDirectChannel = Post("users/@me/channels");


### PR DESCRIPTION
## Description

- Implemented new bearer and rest API client extensions to fetch the current guild member (via oauth2).

## Checklist

- [x] I discussed this PR with the maintainer(s) prior to opening it.
- [x] I read the [contributing guidelines](https://github.com/Quahu/Disqord/blob/master/.github/CONTRIBUTING.md).
- [x] I tested the changes in this PR.
