### PR TITLE
Add Type 11(Attachment) to SlashCommandOptionType

### DIFF
--- a/src/Disqord.Core/Entities/Core/Interactions/Commands/IApplicationCommandInteractionEntities.cs
+++ b/src/Disqord.Core/Entities/Core/Interactions/Commands/IApplicationCommandInteractionEntities.cs
@@ -26,5 +26,10 @@ namespace Disqord
         ///     Gets the resolved messages for the interaction.
         /// </summary>
         IReadOnlyDictionary<Snowflake, IMessage> Messages { get; }
+        
+        /// <summary>
+        ///     Gets the resolved attachments for the interaction.
+        /// </summary>
+        IReadOnlyDictionary<Snowflake, IAttachment> Attachments { get; }
     }
 }

--- a/src/Disqord.Core/Entities/Shared/Transient/Interactions/Commands/TransientApplicationCommandInteractionEntities.cs
+++ b/src/Disqord.Core/Entities/Shared/Transient/Interactions/Commands/TransientApplicationCommandInteractionEntities.cs
@@ -98,7 +98,7 @@ namespace Disqord
                     return ReadOnlyDictionary<Snowflake, IAttachment>.Empty;
                 return _attachments ??= Model.Attachments.Value.ToReadOnlyDictionary(Client,
                     (kvp, _) => kvp.Key,
-                    (kvp, client) => TransientAttachment.Create(kvp.Value));
+                    (kvp, _) => TransientAttachment.Create(kvp.Value));
             }
         }
 

--- a/src/Disqord.Core/Entities/Shared/Transient/Interactions/Commands/TransientApplicationCommandInteractionEntities.cs
+++ b/src/Disqord.Core/Entities/Shared/Transient/Interactions/Commands/TransientApplicationCommandInteractionEntities.cs
@@ -88,6 +88,21 @@ namespace Disqord
             }
         }
         private IReadOnlyDictionary<Snowflake, IMessage> _messages;
+        
+        /// <inheritdoc /> 
+        public IReadOnlyDictionary<Snowflake, IAttachment> Attachments
+        {
+            get
+            {
+                if (!Model.Attachments.HasValue)
+                    return ReadOnlyDictionary<Snowflake, IAttachment>.Empty;
+                return _attachments ??= Model.Attachments.Value.ToReadOnlyDictionary(Client,
+                    (kvp, _) => kvp.Key,
+                    (kvp, client) => TransientAttachment.Create(kvp.Value));
+            }
+        }
+
+        private IReadOnlyDictionary<Snowflake, IAttachment> _attachments;
 
         private readonly Snowflake? _guildId;
 

--- a/src/Disqord.Core/Entities/Shared/Transient/Interactions/Commands/TransientApplicationCommandInteractionEntities.cs
+++ b/src/Disqord.Core/Entities/Shared/Transient/Interactions/Commands/TransientApplicationCommandInteractionEntities.cs
@@ -96,12 +96,12 @@ namespace Disqord
             {
                 if (!Model.Attachments.HasValue)
                     return ReadOnlyDictionary<Snowflake, IAttachment>.Empty;
+                
                 return _attachments ??= Model.Attachments.Value.ToReadOnlyDictionary(
                     kvp => kvp.Key,
                     kvp => new TransientAttachment(kvp.Value) as IAttachment);
             }
         }
-
         private IReadOnlyDictionary<Snowflake, IAttachment> _attachments;
 
         private readonly Snowflake? _guildId;

--- a/src/Disqord.Core/Entities/Shared/Transient/Interactions/Commands/TransientApplicationCommandInteractionEntities.cs
+++ b/src/Disqord.Core/Entities/Shared/Transient/Interactions/Commands/TransientApplicationCommandInteractionEntities.cs
@@ -96,9 +96,9 @@ namespace Disqord
             {
                 if (!Model.Attachments.HasValue)
                     return ReadOnlyDictionary<Snowflake, IAttachment>.Empty;
-                return _attachments ??= Model.Attachments.Value.ToReadOnlyDictionary(Client,
-                    (kvp, _) => kvp.Key,
-                    (kvp, _) => TransientAttachment.Create(kvp.Value));
+                return _attachments ??= Model.Attachments.Value.ToReadOnlyDictionary(
+                    kvp => kvp.Key,
+                    kvp => new TransientAttachment(kvp.Value) as IAttachment);
             }
         }
 

--- a/src/Disqord.Core/Entities/Shared/Transient/Message/User/TransientAttachment.cs
+++ b/src/Disqord.Core/Entities/Shared/Transient/Message/User/TransientAttachment.cs
@@ -35,6 +35,10 @@ namespace Disqord
             : base(model)
         { }
 
+        public static IAttachment Create(AttachmentJsonModel model)
+        {
+            return new TransientAttachment(model);
+        }
         public override string ToString()
             => $"Attachment '{FileName}' ({Id})";
     }

--- a/src/Disqord.Core/Entities/Shared/Transient/Message/User/TransientAttachment.cs
+++ b/src/Disqord.Core/Entities/Shared/Transient/Message/User/TransientAttachment.cs
@@ -34,6 +34,7 @@ namespace Disqord
         public TransientAttachment(AttachmentJsonModel model)
             : base(model)
         { }
+
         public override string ToString()
             => $"Attachment '{FileName}' ({Id})";
     }

--- a/src/Disqord.Core/Entities/Shared/Transient/Message/User/TransientAttachment.cs
+++ b/src/Disqord.Core/Entities/Shared/Transient/Message/User/TransientAttachment.cs
@@ -34,11 +34,6 @@ namespace Disqord
         public TransientAttachment(AttachmentJsonModel model)
             : base(model)
         { }
-
-        public static IAttachment Create(AttachmentJsonModel model)
-        {
-            return new TransientAttachment(model);
-        }
         public override string ToString()
             => $"Attachment '{FileName}' ({Id})";
     }

--- a/src/Disqord.Core/Enums/Interactions/ApplicationCommands/SlashCommandOptionType.cs
+++ b/src/Disqord.Core/Enums/Interactions/ApplicationCommands/SlashCommandOptionType.cs
@@ -57,8 +57,7 @@
         Number = 10,
         
         /// <summary>
-        ///     The option is an attachment,
-        ///     i.e. any image.
+        ///     The option is an attachment.
         /// </summary>
         Attachment = 11
     }

--- a/src/Disqord.Core/Enums/Interactions/ApplicationCommands/SlashCommandOptionType.cs
+++ b/src/Disqord.Core/Enums/Interactions/ApplicationCommands/SlashCommandOptionType.cs
@@ -54,6 +54,12 @@
         /// <summary>
         ///     The option is a floating-point numeric parameter.
         /// </summary>
-        Number = 10
+        Number = 10,
+        
+        /// <summary>
+        ///     The option is an attachment,
+        ///     i.e. any image.
+        /// </summary>
+        Attachment = 11
     }
 }

--- a/src/Disqord.Core/Models/Interactions/ApplicationCommands/ApplicationCommandInteractionDataResolvedJsonModel.cs
+++ b/src/Disqord.Core/Models/Interactions/ApplicationCommands/ApplicationCommandInteractionDataResolvedJsonModel.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Net.Mail;
 using Disqord.Serialization.Json;
 
 namespace Disqord.Models
@@ -19,5 +20,8 @@ namespace Disqord.Models
 
         [JsonProperty("messages")]
         public Optional<Dictionary<Snowflake, MessageJsonModel>> Messages;
+
+        [JsonProperty("attachments")] 
+        public Optional<Dictionary<Snowflake, AttachmentJsonModel>> Attachments;
     }
 }

--- a/src/Disqord.Core/Models/Interactions/ApplicationCommands/ApplicationCommandInteractionDataResolvedJsonModel.cs
+++ b/src/Disqord.Core/Models/Interactions/ApplicationCommands/ApplicationCommandInteractionDataResolvedJsonModel.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Net.Mail;
 using Disqord.Serialization.Json;
 
 namespace Disqord.Models


### PR DESCRIPTION
## Description

Added the `Attachment` option to SlashCommandOptionType.

## Checklist

[//]: # "Put an x in [ ] to check the checkbox, e.g. [x]"

- [ ] I discussed this PR with the maintainer(s) prior to opening it.
- [x] I read the [contributing guidelines](https://github.com/Quahu/Disqord/blob/master/.github/CONTRIBUTING.md).
- [x] I tested the changes in this PR.
