### PR TITLE
Fixed forgotten return value in IThreadChannel.FetchMemberAsync

### DIFF
--- a/src/Disqord.Rest/Extensions/Entity/RestEntityExtensions.Channel.cs
+++ b/src/Disqord.Rest/Extensions/Entity/RestEntityExtensions.Channel.cs
@@ -316,7 +316,7 @@ namespace Disqord.Rest
             return client.RemoveThreadMemberAsync(thread.Id, memberId, options, cancellationToken);
         }
 
-        public static Task FetchMemberAsync(this IThreadChannel thread,
+        public static Task<IThreadMember> FetchMemberAsync(this IThreadChannel thread,
             Snowflake memberId,
             IRestRequestOptions options = null, CancellationToken cancellationToken = default)
         {


### PR DESCRIPTION
## Description

Fixed forgotten return value in IThreadChannel.FetchMemberAsync

## Checklist

[//]: # "Put an x in [ ] to check the checkbox, e.g. [x]"

- [ ] I discussed this PR with the maintainer(s) prior to opening it.
- [x] I read the [contributing guidelines](https://github.com/Quahu/Disqord/blob/master/.github/CONTRIBUTING.md).
- [x] I tested the changes in this PR.
