### PR TITLE
Unified thread permissions computation

### DIFF
--- a/src/Disqord.Core/Discord/Discord.Permissions.cs
+++ b/src/Disqord.Core/Discord/Discord.Permissions.cs
@@ -87,12 +87,13 @@ namespace Disqord
                 if (!permissions.ViewChannels)
                     return ChannelPermissions.None;
 
-                if (channel is ITextChannel && !permissions.SendMessages)
+                if ((channel is ITextChannel && !permissions.SendMessages) || (channel is IThreadChannel && !permissions.SendMessagesInThreads))
                 {
                     permissions &= ~(Permission.SendAttachments |
                         Permission.SendEmbeds |
                         Permission.MentionEveryone |
-                        Permission.UseTextToSpeech);
+                        Permission.UseTextToSpeech |
+                        Permission.SendMessages);
                 }
 
                 return permissions;

--- a/src/Disqord.Core/Discord/Discord.Permissions.cs
+++ b/src/Disqord.Core/Discord/Discord.Permissions.cs
@@ -87,13 +87,21 @@ namespace Disqord
                 if (!permissions.ViewChannels)
                     return ChannelPermissions.None;
 
-                if ((channel is ITextChannel && !permissions.SendMessages) || (channel is IThreadChannel && !permissions.SendMessagesInThreads))
+                // In threads, the SendMessagesInThreads permission is used instead of the SendMessages permission
+                if (channel is IThreadChannel)
+                {
+                    if (permissions.SendMessagesInThreads)
+                        permissions |= Permission.SendMessages;
+                    else
+                        permissions &= ~Permission.SendMessages;
+                }
+
+                if (channel is IMessageGuildChannel && !permissions.SendMessages)
                 {
                     permissions &= ~(Permission.SendAttachments |
                         Permission.SendEmbeds |
                         Permission.MentionEveryone |
-                        Permission.UseTextToSpeech |
-                        Permission.SendMessages);
+                        Permission.UseTextToSpeech);
                 }
 
                 return permissions;

--- a/src/Disqord.Core/Entities/Shared/Transient/Channels/Guild/Threads/TransientThreadChannel.cs
+++ b/src/Disqord.Core/Entities/Shared/Transient/Channels/Guild/Threads/TransientThreadChannel.cs
@@ -7,13 +7,13 @@ namespace Disqord
     public class TransientThreadChannel : TransientMessageGuildChannel, IThreadChannel
     {
         /// <inheritdoc/>
-        public override Snowflake? CategoryId => null;
+        public override Snowflake? CategoryId => throw new InvalidOperationException($"{nameof(TransientThreadChannel)} does not support {nameof(CategoryId)}.");
 
         /// <inheritdoc/>
-        public override int Position => 0;
+        public override int Position => throw new InvalidOperationException($"{nameof(TransientThreadChannel)} does not support {nameof(Position)}.");
 
         /// <inheritdoc/>
-        public override IReadOnlyList<IOverwrite> Overwrites => Array.Empty<IOverwrite>();
+        public override IReadOnlyList<IOverwrite> Overwrites => throw new InvalidOperationException($"{nameof(TransientThreadChannel)} does not support {nameof(Overwrites)}.");
 
         /// <inheritdoc/>
         public Snowflake ChannelId => Model.ParentId.Value.Value;

--- a/src/Disqord.Rest/Extensions/Entity/RestEntityExtensions.Channel.cs
+++ b/src/Disqord.Rest/Extensions/Entity/RestEntityExtensions.Channel.cs
@@ -316,7 +316,7 @@ namespace Disqord.Rest
             return client.RemoveThreadMemberAsync(thread.Id, memberId, options, cancellationToken);
         }
 
-        public static Task FetchMemberAsync(this IThreadChannel thread,
+        public static Task<IThreadMember> FetchMemberAsync(this IThreadChannel thread,
             Snowflake memberId,
             IRestRequestOptions options = null, CancellationToken cancellationToken = default)
         {


### PR DESCRIPTION
## Description

Unified the behavior of `Discord.Permissions.CalculatePermissions` when computing thread permissions with text channel permissions.

## Checklist

[//]: # "Put an x in [ ] to check the checkbox, e.g. [x]"

- [x] I discussed this PR with the maintainer(s) prior to opening it.
- [x] I read the [contributing guidelines](https://github.com/Quahu/Disqord/blob/master/.github/CONTRIBUTING.md).
- [x] I tested the changes in this PR.
