### PR TITLE
Fix a typo

### DIFF
--- a/src/Disqord/Hosting/DiscordClientHostingContext.cs
+++ b/src/Disqord/Hosting/DiscordClientHostingContext.cs
@@ -39,7 +39,7 @@ namespace Disqord.Hosting
         public virtual IList<Assembly> ServiceAssemblies { get; set; } = new List<Assembly> { Assembly.GetEntryAssembly() };
 
         /// <summary>
-        ///     Gets or sets the status> the bot will identify with.
+        ///     Gets or sets the status the bot will identify with.
         /// </summary>
         /// <remarks>
         ///     Defaults to <see langword="null"/>, i.e. the bot will show up as <see cref="UserStatus.Online"/>.


### PR DESCRIPTION
## Description

Removes a meaningless `>` from documentation of DiscordClientHostingContext.Status.

## Checklist

[//]: # "Put an x in [ ] to check the checkbox, e.g. [x]"

- [ ] I discussed this PR with the maintainer(s) prior to opening it.
- [x] I read the [contributing guidelines](https://github.com/Quahu/Disqord/blob/master/.github/CONTRIBUTING.md).
- [x] I tested the changes in this PR.