### PR TITLE
Update create stage endpoint, events auditlog

### DIFF
--- a/src/Disqord.Core/Entities/Core/AuditLogs/GuildEvent/Data/IGuildEventAuditLogChanges.cs
+++ b/src/Disqord.Core/Entities/Core/AuditLogs/GuildEvent/Data/IGuildEventAuditLogChanges.cs
@@ -8,6 +8,8 @@
 
         AuditLogChange<string> Description { get; }
 
+        AuditLogChange<string> CoverImageHash { get; }
+
         AuditLogChange<GuildEventTargetType> TargetType { get; }
 
         AuditLogChange<string> Location { get; }

--- a/src/Disqord.Core/Entities/Core/AuditLogs/GuildEvent/Data/IGuildEventAuditLogData.cs
+++ b/src/Disqord.Core/Entities/Core/AuditLogs/GuildEvent/Data/IGuildEventAuditLogData.cs
@@ -8,6 +8,8 @@
 
         Optional<string> Description { get; }
 
+        Optional<string> CoverImageHash { get; }
+
         Optional<GuildEventTargetType> TargetType { get; }
 
         Optional<string> Location { get; }

--- a/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/GuildEvent/Data/TransientGuildEventAuditLogChanges.cs
+++ b/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/GuildEvent/Data/TransientGuildEventAuditLogChanges.cs
@@ -11,6 +11,8 @@ namespace Disqord.AuditLogs
 
         public AuditLogChange<string> Description { get; }
 
+        public AuditLogChange<string> CoverImageHash { get; }
+
         public AuditLogChange<GuildEventTargetType> TargetType { get; }
 
         public AuditLogChange<string> Location { get; }
@@ -39,6 +41,11 @@ namespace Disqord.AuditLogs
                     case "description":
                     {
                         Description = AuditLogChange<string>.Convert(change);
+                        break;
+                    }
+                    case "image_hash":
+                    {
+                        CoverImageHash = AuditLogChange<string>.Convert(change);
                         break;
                     }
                     case "entity_type":

--- a/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/GuildEvent/Data/TransientGuildEventAuditLogData.cs
+++ b/src/Disqord.Core/Entities/Shared/Transient/AuditLogs/GuildEvent/Data/TransientGuildEventAuditLogData.cs
@@ -10,6 +10,8 @@ namespace Disqord.AuditLogs
 
         public Optional<string> Description { get; }
 
+        public Optional<string> CoverImageHash { get; }
+
         public Optional<GuildEventTargetType> TargetType { get; }
 
         public Optional<string> Location { get; }
@@ -26,6 +28,7 @@ namespace Disqord.AuditLogs
                 ChannelId = changes.ChannelId.NewValue;
                 Name = changes.Name.NewValue;
                 Description = changes.Description.NewValue;
+                CoverImageHash = changes.CoverImageHash.NewValue;
                 TargetType = changes.TargetType.NewValue;
                 Location = changes.Location.NewValue;
                 PrivacyLevel = changes.PrivacyLevel.NewValue;
@@ -36,6 +39,7 @@ namespace Disqord.AuditLogs
                 ChannelId = changes.ChannelId.OldValue;
                 Name = changes.Name.OldValue;
                 Description = changes.Description.OldValue;
+                CoverImageHash = changes.CoverImageHash.OldValue;
                 TargetType = changes.TargetType.OldValue;
                 Location = changes.Location.OldValue;
                 PrivacyLevel = changes.PrivacyLevel.OldValue;

--- a/src/Disqord.Rest.Api/Content/Json/CreateStageInstanceJsonRestRequestContent.cs
+++ b/src/Disqord.Rest.Api/Content/Json/CreateStageInstanceJsonRestRequestContent.cs
@@ -12,5 +12,8 @@ namespace Disqord.Rest.Api
 
         [JsonProperty("privacy_level")]
         public Optional<PrivacyLevel> PrivacyLevel;
+
+        [JsonProperty("send_start_notification")]
+        public Optional<bool> SendStartNotification;
     }
 }

--- a/src/Disqord.Rest/ActionProperties/Create/CreateStageActionProperties.cs
+++ b/src/Disqord.Rest/ActionProperties/Create/CreateStageActionProperties.cs
@@ -3,5 +3,7 @@ namespace Disqord
     public sealed class CreateStageActionProperties
     {
         public Optional<PrivacyLevel> PrivacyLevel { internal get; set; }
+
+        public Optional<bool> NotifyEveryone { internal get; set; }
     }
 }

--- a/src/Disqord.Rest/Extensions/RestClientExtensions.Stages.cs
+++ b/src/Disqord.Rest/Extensions/RestClientExtensions.Stages.cs
@@ -20,7 +20,8 @@ namespace Disqord.Rest
             {
                 ChannelId = channelId,
                 Topic = topic,
-                PrivacyLevel = properties.PrivacyLevel
+                PrivacyLevel = properties.PrivacyLevel,
+                SendStartNotification = properties.NotifyEveryone
             };
 
             var model = await client.ApiClient.CreateStageInstanceAsync(channelId, content, options, cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
## Description
- Added send start notification field for create stage endpoint (discord/discord-api-docs#4706)
- Added missing audit log key for guild events (discord/discord-api-docs#4707)

## Checklist

- [x] I discussed this PR with the maintainer(s) prior to opening it.
- [x] I read the [contributing guidelines](https://github.com/Quahu/Disqord/blob/master/.github/CONTRIBUTING.md).
- [x] I tested the changes in this PR.
