### PR TITLE
Add default_auto_archive_duration field

### DIFF
--- a/src/Disqord.Rest.Api/Content/Json/CreateGuildChannelJsonRestRequestContent.cs
+++ b/src/Disqord.Rest.Api/Content/Json/CreateGuildChannelJsonRestRequestContent.cs
@@ -35,6 +35,9 @@ namespace Disqord.Rest.Api
         [JsonProperty("nsfw")]
         public Optional<bool> Nsfw;
 
+        [JsonProperty("default_auto_archive_duration")]
+        public Optional<int> DefaultAutoArchiveDuration;
+
         [JsonProperty("rtc_region")]
         public Optional<string> RtcRegion;
 

--- a/src/Disqord.Rest/ActionProperties/Create/Channel/CreateTextChannelActionProperties.cs
+++ b/src/Disqord.Rest/ActionProperties/Create/Channel/CreateTextChannelActionProperties.cs
@@ -10,6 +10,8 @@ namespace Disqord
 
         public Optional<bool> IsNsfw { internal get; set; }
 
+        public Optional<TimeSpan> DefaultAutomaticArchiveDuration { internal get; set; }
+
         internal CreateTextChannelActionProperties()
         { }
     }

--- a/src/Disqord.Rest/Extensions/RestClientExtensions.Guild.cs
+++ b/src/Disqord.Rest/Extensions/RestClientExtensions.Guild.cs
@@ -133,6 +133,7 @@ namespace Disqord.Rest
                     content.Topic = textProperties.Topic;
                     content.RateLimitPerUser = Optional.Convert(textProperties.Slowmode, x => (int) x.TotalSeconds);
                     content.Nsfw = textProperties.IsNsfw;
+                    content.DefaultAutoArchiveDuration = Optional.Convert(textProperties.DefaultAutomaticArchiveDuration, x => (int) x.TotalMinutes);
                 }
                 else if (properties is CreateVoiceChannelActionProperties voiceProperties)
                 {


### PR DESCRIPTION
## Description

This adds the `default_auto_archive_duration` field to `CreateGuildChannelJsonRestRequestContent`

## Checklist

- [x] I discussed this PR with the maintainer(s) prior to opening it.
- [x] I read the [contributing guidelines](https://github.com/Quahu/Disqord/blob/master/.github/CONTRIBUTING.md).
- [x] I tested the changes in this PR.
