### PR TITLE
Fixed an inverted length check for Snowflake.Parse().

### DIFF
--- a/src/Disqord.Core/Snowflake/Snowflake.cs
+++ b/src/Disqord.Core/Snowflake/Snowflake.cs
@@ -135,7 +135,7 @@ namespace Disqord
         {
             const string exceptionMessage = "The input was in an incorrect format.";
 
-            if (value.Length >= 15 && value.Length < 21)
+            if (value.Length < 15 && value.Length >= 21)
                 throw new FormatException(exceptionMessage);
 
             try

--- a/src/Disqord.Core/Snowflake/Snowflake.cs
+++ b/src/Disqord.Core/Snowflake/Snowflake.cs
@@ -135,7 +135,7 @@ namespace Disqord
         {
             const string exceptionMessage = "The input was in an incorrect format.";
 
-            if (value.Length < 15 && value.Length >= 21)
+            if (value.Length < 15 || value.Length >= 21)
                 throw new FormatException(exceptionMessage);
 
             try


### PR DESCRIPTION
## Description

Fixes `Snowflake.Parse()` erroneously throwing on valid-length values. This brings the code inline with the bot-rewrite branch as well which seems to have stealthily fixed this issue.

## Checklist

[//]: # "Put an x in [ ] to check the checkbox, e.g. [x]"

- [ ] I discussed this PR with the maintainer(s) prior to opening it.
- [x] I read the [contributing guidelines](https://github.com/Quahu/Disqord/blob/master/.github/CONTRIBUTING.md).
- [x] I tested the changes in this PR.
