### PR TITLE
Allow creation of forum tags without emoji

### DIFF
--- a/src/Disqord.Core/Entities/Local/Guild/Forums/LocalForumTag.cs
+++ b/src/Disqord.Core/Entities/Local/Guild/Forums/LocalForumTag.cs
@@ -41,9 +41,6 @@ public class LocalForumTag : ILocalConstruct<LocalForumTag>, IJsonConvertible<Fo
     /// <summary>
     ///     Gets or sets the emoji of this tag.
     /// </summary>
-    /// <remarks>
-    ///     This property is required.
-    /// </remarks>
     public Optional<LocalEmoji> Emoji { get; set; }
 
     /// <summary>
@@ -74,7 +71,6 @@ public class LocalForumTag : ILocalConstruct<LocalForumTag>, IJsonConvertible<Fo
     public ForumTagJsonModel ToModel()
     {
         OptionalGuard.HasValue(Name);
-        OptionalGuard.HasValue(Emoji);
 
         var model = new ForumTagJsonModel
         {


### PR DESCRIPTION
## Description

Removed guard clause that ensured an emoji was provided for the LocalForumTag

## Checklist

[//]: # "Put an x in [ ] to check the checkbox, e.g. [x]"

- [x] I discussed this PR with the maintainer(s) prior to opening it.
- [x] I read the [contributing guidelines](https://github.com/Quahu/Disqord/blob/master/.github/CONTRIBUTING.md).
- [x] I tested the changes in this PR.
