### PR TITLE
made AreEqual check for Subcommand & SubcommandGroup

### DIFF
--- a/src/Disqord.Bot/Commands/Implementation/Application/Cache/Default/DefaultApplicationCommandCacheProvider.Utilities.cs
+++ b/src/Disqord.Bot/Commands/Implementation/Application/Cache/Default/DefaultApplicationCommandCacheProvider.Utilities.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using Qommon;
+using System.Linq;
 
 namespace Disqord.Bot.Commands.Application.Default;
 
@@ -51,6 +52,20 @@ public partial class DefaultApplicationCommandCacheProvider
 
         if (modelCollection.Length != localCollection.Count)
             return false;
+
+        if (localCollection is IList<LocalSlashCommandOption> lc 
+            && lc.Any(x => x.Type.Value is SlashCommandOptionType.Subcommand or SlashCommandOptionType.SubcommandGroup))
+        {
+            foreach (var local in localCollection)
+            {
+                if (modelCollection.Any(x => x is not null && x.Equals(local)))
+                    continue;
+
+                return false;
+            }
+
+            return true;
+        }
 
         for (var i = 0; i < modelCollection.Length; i++)
         {


### PR DESCRIPTION
## Description

I have added an additional if statement to prevent changes being detected even though only the order of the values in the list is different which is not relevant for SubCommands & SubCommandGroup

[Addressing my issue on discord](https://discord.com/channels/416256456505950215/1165414150571302982)

## Checklist

- [ ] I discussed this PR with the maintainer(s) prior to opening it.
- [x ] I read the [contributing guidelines](https://github.com/Quahu/Disqord/blob/master/.github/CONTRIBUTING.md).
- [x] I tested the changes in this PR.