### PR TITLE
Implement application emojis

### DIFF
--- a/src/Disqord.Core/Entities/Core/Emoji/IApplicationEmoji.cs
+++ b/src/Disqord.Core/Entities/Core/Emoji/IApplicationEmoji.cs
@@ -5,20 +5,5 @@ namespace Disqord;
 /// <summary>
 ///     Represents a custom emoji (e.g. <c>&lt;:professor:667582610431803437&gt;</c>) retrieved from an application.
 /// </summary>
-public interface IApplicationEmoji : ICustomEmoji, IApplicationEntity, IClientEntity, INamableEntity, IJsonUpdatable<EmojiJsonModel>
-{
-    /// <summary>
-    ///     Gets the user that created this emoji.
-    /// </summary>
-    IUser? Creator { get; }
-
-    /// <summary>
-    ///     Gets whether this emoji requires colons in chat.
-    /// </summary>
-    bool RequiresColons { get; }
-
-    /// <summary>
-    ///     Gets whether this emoji is managed by an integration.
-    /// </summary>
-    bool IsManaged { get; }
-}
+public interface IApplicationEmoji : IOwnedEmoji, IApplicationEntity, IClientEntity, INamableEntity, IJsonUpdatable<EmojiJsonModel>
+{ }

--- a/src/Disqord.Core/Entities/Core/Emoji/IApplicationEmoji.cs
+++ b/src/Disqord.Core/Entities/Core/Emoji/IApplicationEmoji.cs
@@ -1,0 +1,24 @@
+﻿using Disqord.Models;
+
+namespace Disqord;
+
+/// <summary>
+///     Represents a custom emoji (e.g. <c>&lt;:professor:667582610431803437&gt;</c>) retrieved from an application.
+/// </summary>
+public interface IApplicationEmoji : ICustomEmoji, IApplicationEntity, IClientEntity, INamableEntity, IJsonUpdatable<EmojiJsonModel>
+{
+    /// <summary>
+    ///     Gets the user that created this emoji.
+    /// </summary>
+    IUser? Creator { get; }
+
+    /// <summary>
+    ///     Gets whether this emoji requires colons in chat.
+    /// </summary>
+    bool RequiresColons { get; }
+
+    /// <summary>
+    ///     Gets whether this emoji is managed by an integration.
+    /// </summary>
+    bool IsManaged { get; }
+}

--- a/src/Disqord.Core/Entities/Core/Emoji/ICustomEmoji.cs
+++ b/src/Disqord.Core/Entities/Core/Emoji/ICustomEmoji.cs
@@ -3,7 +3,7 @@
 namespace Disqord;
 
 /// <summary>
-///     Represents a custom emoji (e.g. <c>&lt;:professor:667582610431803437&gt;</c>) tied to a possibly unknown guild.
+///     Represents a custom emoji (e.g. <c>&lt;:professor:667582610431803437&gt;</c>).
 /// </summary>
 public interface ICustomEmoji : IEmoji, IIdentifiableEntity, ITaggableEntity, IEquatable<ICustomEmoji>
 {
@@ -11,7 +11,7 @@ public interface ICustomEmoji : IEmoji, IIdentifiableEntity, ITaggableEntity, IE
     ///     Gets whether this emoji is animated.
     /// </summary>
     /// <remarks>
-    ///     This property is not reliable unless this instance is an <see cref="IGuildEmoji"/>.
+    ///     This property is not reliable unless this instance is an <see cref="IGuildEmoji"/> or <see cref="IApplicationEmoji"/>.
     /// </remarks>
     bool IsAnimated { get; }
 }

--- a/src/Disqord.Core/Entities/Core/Emoji/IGuildEmoji.cs
+++ b/src/Disqord.Core/Entities/Core/Emoji/IGuildEmoji.cs
@@ -6,27 +6,12 @@ namespace Disqord;
 /// <summary>
 ///     Represents a custom emoji (e.g. <c>&lt;:professor:667582610431803437&gt;</c>) retrieved from a known guild.
 /// </summary>
-public interface IGuildEmoji : ICustomEmoji, IGuildEntity, IClientEntity, INamableEntity, IJsonUpdatable<EmojiJsonModel>
+public interface IGuildEmoji : IOwnedEmoji, IGuildEntity, IClientEntity, INamableEntity, IJsonUpdatable<EmojiJsonModel>
 {
     /// <summary>
     ///     Gets the role IDs that can use this emoji.
     /// </summary>
     IReadOnlyList<Snowflake> RoleIds { get; }
-
-    /// <summary>
-    ///     Gets the user that created this emoji.
-    /// </summary>
-    IUser? Creator { get; }
-
-    /// <summary>
-    ///     Gets whether this emoji requires colons in chat.
-    /// </summary>
-    bool RequiresColons { get; }
-
-    /// <summary>
-    ///     Gets whether this emoji is managed by an integration.
-    /// </summary>
-    bool IsManaged { get; }
 
     /// <summary>
     ///     Gets whether this emoji is available.

--- a/src/Disqord.Core/Entities/Core/Emoji/IOwnedEmoji.cs
+++ b/src/Disqord.Core/Entities/Core/Emoji/IOwnedEmoji.cs
@@ -1,0 +1,22 @@
+﻿namespace Disqord;
+
+/// <summary>
+///     Represents a custom emoji (e.g. <c>&lt;:professor:667582610431803437&gt;</c>) tied to a possibly unknown guild or application.
+/// </summary>
+public interface IOwnedEmoji : ICustomEmoji
+{
+    /// <summary>
+    ///     Gets the user that created this emoji.
+    /// </summary>
+    IUser? Creator { get; }
+
+    /// <summary>
+    ///     Gets whether this emoji requires colons in chat.
+    /// </summary>
+    bool RequiresColons { get; }
+
+    /// <summary>
+    ///     Gets whether this emoji is managed by an integration.
+    /// </summary>
+    bool IsManaged { get; }
+}

--- a/src/Disqord.Core/Entities/Core/IApplicationEntity.cs
+++ b/src/Disqord.Core/Entities/Core/IApplicationEntity.cs
@@ -1,0 +1,12 @@
+﻿namespace Disqord;
+
+/// <summary>
+///     Represents a Discord entity that exists within an application.
+/// </summary>
+public interface IApplicationEntity
+{
+    /// <summary>
+    ///     Gets the ID of the application this entity is tied to.
+    /// </summary>
+    Snowflake ApplicationId { get; }
+}

--- a/src/Disqord.Core/Entities/Core/IApplicationEntity.cs
+++ b/src/Disqord.Core/Entities/Core/IApplicationEntity.cs
@@ -3,7 +3,7 @@
 /// <summary>
 ///     Represents a Discord entity that exists within an application.
 /// </summary>
-public interface IApplicationEntity
+public interface IApplicationEntity : IEntity
 {
     /// <summary>
     ///     Gets the ID of the application this entity is tied to.

--- a/src/Disqord.Core/Entities/Transient/Emoji/TransientApplicationEmoji.cs
+++ b/src/Disqord.Core/Entities/Transient/Emoji/TransientApplicationEmoji.cs
@@ -1,0 +1,59 @@
+﻿using Disqord.Models;
+using Qommon;
+
+namespace Disqord;
+
+public class TransientApplicationEmoji : TransientClientEntity<EmojiJsonModel>, IApplicationEmoji
+{
+    /// <inheritdoc />
+    public Snowflake Id => Model.Id!.Value;
+
+    /// <inheritdoc />
+    public Snowflake ApplicationId { get; }
+
+    /// <inheritdoc cref="INamableEntity.Name"/>
+    public string Name => Model.Name!;
+    
+    /// <inheritdoc/>
+    public bool IsAnimated => Model.Animated.Value;
+    
+    /// <inheritdoc/>
+    public IUser? Creator => _creator ??= Optional.ConvertOrDefault(Model.User, static (user, client) => new TransientUser(client, user), Client);
+    
+    private IUser? _creator;
+    
+    /// <inheritdoc/>
+    public bool RequiresColons => Model.RequireColons.Value;
+    
+    /// <inheritdoc/>
+    public bool IsManaged => Model.Managed.Value;
+    
+    /// <inheritdoc/>
+    public string Tag => ToString();
+
+    public TransientApplicationEmoji(IClient client, Snowflake applicationId, EmojiJsonModel model)
+        : base(client, model)
+    {
+        ApplicationId = applicationId;
+    }
+
+    public bool Equals(IEmoji? other)
+    {
+        return Comparers.Emoji.Equals(this, other);
+    }
+    
+    public bool Equals(ICustomEmoji? other)
+    {
+        return Comparers.Emoji.Equals(this, other);
+    }
+    
+    public override int GetHashCode()
+    {
+        return Comparers.Emoji.GetHashCode(this);
+    }
+
+    public override string ToString()
+    {
+        return this.GetString();
+    }
+}

--- a/src/Disqord.Core/Models/Application/ApplicationEmojisJsonModel.cs
+++ b/src/Disqord.Core/Models/Application/ApplicationEmojisJsonModel.cs
@@ -1,0 +1,9 @@
+﻿using Disqord.Serialization.Json;
+
+namespace Disqord.Models;
+
+public class ApplicationEmojisJsonModel : JsonModel
+{
+    [JsonProperty("items")] 
+    public EmojiJsonModel[] Items = null!;
+}

--- a/src/Disqord.Rest.Api/Content/Json/CreateApplicationEmojiJsonRestRequestContent.cs
+++ b/src/Disqord.Rest.Api/Content/Json/CreateApplicationEmojiJsonRestRequestContent.cs
@@ -1,0 +1,19 @@
+﻿using System.IO;
+using Disqord.Serialization.Json;
+
+namespace Disqord.Rest.Api;
+
+public class CreateApplicationEmojiJsonRestRequestContent : JsonModelRestRequestContent
+{
+    [JsonProperty("name")]
+    public string Name;
+
+    [JsonProperty("image")]
+    public Stream Image;
+
+    public CreateApplicationEmojiJsonRestRequestContent(string name, Stream image)
+    {
+        Name = name;
+        Image = image;
+    }
+}

--- a/src/Disqord.Rest.Api/Content/Json/ModifyApplicationEmojiJsonRestRequestContent.cs
+++ b/src/Disqord.Rest.Api/Content/Json/ModifyApplicationEmojiJsonRestRequestContent.cs
@@ -1,0 +1,10 @@
+﻿using Disqord.Serialization.Json;
+using Qommon;
+
+namespace Disqord.Rest.Api;
+
+public class ModifyApplicationEmojiJsonRestRequestContent : JsonModelRestRequestContent
+{
+    [JsonProperty("name")]
+    public Optional<string> Name;
+}

--- a/src/Disqord.Rest.Api/Methods/RestApiClientExtensions.Emoji.cs
+++ b/src/Disqord.Rest.Api/Methods/RestApiClientExtensions.Emoji.cs
@@ -6,6 +6,46 @@ namespace Disqord.Rest.Api;
 
 public static partial class RestApiClientExtensions
 {
+    public static Task<EmojiJsonModel[]> FetchApplicationEmojisAsync(this IRestApiClient client,
+        Snowflake applicationId,
+        IRestRequestOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        var route = Format(Route.Emoji.GetApplicationEmojis, applicationId);
+        return client.ExecuteAsync<EmojiJsonModel[]>(route, null, options, cancellationToken);
+    }
+
+    public static Task<EmojiJsonModel> FetchApplicationEmojiAsync(this IRestApiClient client,
+        Snowflake applicationId, Snowflake emojiId,
+        IRestRequestOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        var route = Format(Route.Emoji.GetApplicationEmoji, applicationId, emojiId);
+        return client.ExecuteAsync<EmojiJsonModel>(route, null, options, cancellationToken);
+    }
+    
+    public static Task<EmojiJsonModel> CreateApplicationEmojiAsync(this IRestApiClient client,
+        Snowflake applicationId, CreateApplicationEmojiJsonRestRequestContent content,
+        IRestRequestOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        var route = Format(Route.Emoji.CreateApplicationEmoji, applicationId);
+        return client.ExecuteAsync<EmojiJsonModel>(route, content, options, cancellationToken);
+    }
+    
+    public static Task<EmojiJsonModel> ModifyApplicationEmojiAsync(this IRestApiClient client,
+        Snowflake applicationId, Snowflake emojiId, ModifyApplicationEmojiJsonRestRequestContent content,
+        IRestRequestOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        var route = Format(Route.Emoji.ModifyApplicationEmoji, applicationId, emojiId);
+        return client.ExecuteAsync<EmojiJsonModel>(route, content, options, cancellationToken);
+    }
+    
+    public static Task DeleteApplicationEmojiAsync(this IRestApiClient client,
+        Snowflake applicationId, Snowflake emojiId,
+        IRestRequestOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        var route = Format(Route.Emoji.DeleteApplicationEmoji, applicationId, emojiId);
+        return client.ExecuteAsync<EmojiJsonModel>(route, null, options, cancellationToken);
+    }
+    
     public static Task<EmojiJsonModel[]> FetchGuildEmojisAsync(this IRestApiClient client,
         Snowflake guildId,
         IRestRequestOptions? options = null, CancellationToken cancellationToken = default)

--- a/src/Disqord.Rest.Api/Methods/RestApiClientExtensions.Emoji.cs
+++ b/src/Disqord.Rest.Api/Methods/RestApiClientExtensions.Emoji.cs
@@ -6,12 +6,12 @@ namespace Disqord.Rest.Api;
 
 public static partial class RestApiClientExtensions
 {
-    public static Task<EmojiJsonModel[]> FetchApplicationEmojisAsync(this IRestApiClient client,
+    public static Task<ApplicationEmojisJsonModel> FetchApplicationEmojisAsync(this IRestApiClient client,
         Snowflake applicationId,
         IRestRequestOptions? options = null, CancellationToken cancellationToken = default)
     {
         var route = Format(Route.Emoji.GetApplicationEmojis, applicationId);
-        return client.ExecuteAsync<EmojiJsonModel[]>(route, null, options, cancellationToken);
+        return client.ExecuteAsync<ApplicationEmojisJsonModel>(route, null, options, cancellationToken);
     }
 
     public static Task<EmojiJsonModel> FetchApplicationEmojiAsync(this IRestApiClient client,

--- a/src/Disqord.Rest.Api/Requests/Routing/Default/Route.Static.cs
+++ b/src/Disqord.Rest.Api/Requests/Routing/Default/Route.Static.cs
@@ -112,6 +112,16 @@ public sealed partial class Route
 
     public static class Emoji
     {
+        public static readonly Route GetApplicationEmojis = Get("applications/{0:application_id}/emojis");
+        
+        public static readonly Route GetApplicationEmoji = Get("applications/{0:application_id}/emojis/{1:emoji_id}");
+        
+        public static readonly Route CreateApplicationEmoji = Post("applications/{0:application_id}/emojis");
+        
+        public static readonly Route ModifyApplicationEmoji = Patch("applications/{0:application_id}/emojis/{1:emoji_id}");
+        
+        public static readonly Route DeleteApplicationEmoji = Delete("applications/{0:application_id}/emojis/{1:emoji_id}");
+        
         public static readonly Route GetGuildEmojis = Get("guilds/{0:guild_id}/emojis");
 
         public static readonly Route GetGuildEmoji = Get("guilds/{0:guild_id}/emojis/{1:emoji_id}");

--- a/src/Disqord.Rest/ActionProperties/Modify/ModifyApplicationEmojiActionProperties.cs
+++ b/src/Disqord.Rest/ActionProperties/Modify/ModifyApplicationEmojiActionProperties.cs
@@ -1,0 +1,11 @@
+﻿using Qommon;
+
+namespace Disqord;
+
+public class ModifyApplicationEmojiActionProperties
+{
+    public Optional<string> Name { internal get; set; }
+
+    internal ModifyApplicationEmojiActionProperties()
+    { }
+}

--- a/src/Disqord.Rest/Extensions/Entity/RestEntityExtensions.Application.cs
+++ b/src/Disqord.Rest/Extensions/Entity/RestEntityExtensions.Application.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Disqord.Rest;
+
+public static partial class RestEntityExtensions
+{
+    public static Task<IReadOnlyList<IApplicationEmoji>> FetchEmojisAsync(this IApplication application,
+        IRestRequestOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        var client = application.GetRestClient();
+        return client.FetchApplicationEmojisAsync(application.Id, options, cancellationToken);
+    }
+
+    public static Task<IApplicationEmoji> FetchEmojiAsync(this IApplication application,
+        Snowflake emojiId,
+        IRestRequestOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        var client = application.GetRestClient();
+        return client.FetchApplicationEmojiAsync(application.Id, emojiId, options, cancellationToken);
+    }
+    
+    public static Task<IApplicationEmoji> CreateEmojiAsync(this IApplication application,
+        string name, Stream image,
+        IRestRequestOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        var client = application.GetRestClient();
+        return client.CreateApplicationEmojiAsync(application.Id, name, image, options, cancellationToken);
+    }
+    
+    public static Task<IApplicationEmoji> ModifyEmojiAsync(this IApplication application,
+        Snowflake emojiId, Action<ModifyApplicationEmojiActionProperties> action,
+        IRestRequestOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        var client = application.GetRestClient();
+        return client.ModifyApplicationEmojiAsync(application.Id, emojiId, action, options, cancellationToken);
+    }
+    
+    public static Task DeleteEmojiAsync(this IApplication application,
+        Snowflake emojiId,
+        IRestRequestOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        var client = application.GetRestClient();
+        return client.DeleteApplicationEmojiAsync(application.Id, emojiId, options, cancellationToken);
+    }
+}

--- a/src/Disqord.Rest/Extensions/Entity/RestEntityExtensions.Emoji.cs
+++ b/src/Disqord.Rest/Extensions/Entity/RestEntityExtensions.Emoji.cs
@@ -6,6 +6,21 @@ namespace Disqord.Rest;
 
 public static partial class RestEntityExtensions
 {
+    public static Task<IApplicationEmoji> ModifyAsync(this IApplicationEmoji emoji,
+        Action<ModifyApplicationEmojiActionProperties> action,
+        IRestRequestOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        var client = emoji.GetRestClient();
+        return client.ModifyApplicationEmojiAsync(emoji.ApplicationId, emoji.Id, action, options, cancellationToken);
+    }
+
+    public static Task DeleteAsync(this IApplicationEmoji emoji,
+        IRestRequestOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        var client = emoji.GetRestClient();
+        return client.DeleteApplicationEmojiAsync(emoji.ApplicationId, emoji.Id, options, cancellationToken);
+    }
+    
     public static Task<IGuildEmoji> ModifyAsync(this IGuildEmoji emoji,
         Action<ModifyGuildEmojiActionProperties> action,
         IRestRequestOptions? options = null, CancellationToken cancellationToken = default)

--- a/src/Disqord.Rest/Extensions/Entity/RestEntityExtensions.User.cs
+++ b/src/Disqord.Rest/Extensions/Entity/RestEntityExtensions.User.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/src/Disqord.Rest/Extensions/Entity/RestEntityExtensions.User.cs
+++ b/src/Disqord.Rest/Extensions/Entity/RestEntityExtensions.User.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/src/Disqord.Rest/Extensions/RestClientExtensions.Emoji.cs
+++ b/src/Disqord.Rest/Extensions/RestClientExtensions.Emoji.cs
@@ -12,6 +12,60 @@ namespace Disqord.Rest;
 
 public static partial class RestClientExtensions
 {
+    public static async Task<IReadOnlyList<IApplicationEmoji>> FetchApplicationEmojisAsync(this IRestClient client,
+        Snowflake applicationId,
+        IRestRequestOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        var models = await client.ApiClient.FetchApplicationEmojisAsync(applicationId, options, cancellationToken).ConfigureAwait(false);
+        return models.ToReadOnlyList((client, applicationId), static (model, state) =>
+        {
+            var (client, applicationId) = state;
+            return new TransientApplicationEmoji(client, applicationId, model);
+        });
+    }
+
+    public static async Task<IApplicationEmoji> FetchApplicationEmojiAsync(this IRestClient client,
+        Snowflake applicationId, Snowflake emojiId,
+        IRestRequestOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        var model = await client.ApiClient.FetchApplicationEmojiAsync(applicationId, emojiId, options, cancellationToken).ConfigureAwait(false);
+        return new TransientApplicationEmoji(client, applicationId, model);
+    }
+    
+    public static async Task<IApplicationEmoji> CreateApplicationEmojiAsync(this IRestClient client,
+        Snowflake applicationId, string name, Stream image,
+        IRestRequestOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        var content = new CreateApplicationEmojiJsonRestRequestContent(name, image);
+
+        var model = await client.ApiClient.CreateApplicationEmojiAsync(applicationId, content, options, cancellationToken).ConfigureAwait(false);
+        return new TransientApplicationEmoji(client, applicationId, model);
+    }
+    
+    public static async Task<IApplicationEmoji> ModifyApplicationEmojiAsync(this IRestClient client,
+        Snowflake applicationId, Snowflake emojiId, Action<ModifyApplicationEmojiActionProperties> action,
+        IRestRequestOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        Guard.IsNotNull(action);
+
+        var properties = new ModifyApplicationEmojiActionProperties();
+        action.Invoke(properties);
+        var content = new ModifyApplicationEmojiJsonRestRequestContent()
+        {
+            Name = properties.Name
+        };
+
+        var model = await client.ApiClient.ModifyApplicationEmojiAsync(applicationId, emojiId, content, options, cancellationToken).ConfigureAwait(false);
+        return new TransientApplicationEmoji(client, applicationId, model);
+    }
+    
+    public static Task DeleteApplicationEmojiAsync(this IRestClient client,
+        Snowflake applicationId, Snowflake emojiId,
+        IRestRequestOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        return client.ApiClient.DeleteApplicationEmojiAsync(applicationId, emojiId, options, cancellationToken);
+    }
+    
     public static async Task<IReadOnlyList<IGuildEmoji>> FetchGuildEmojisAsync(this IRestClient client,
         Snowflake guildId,
         IRestRequestOptions? options = null, CancellationToken cancellationToken = default)

--- a/src/Disqord.Rest/Extensions/RestClientExtensions.Emoji.cs
+++ b/src/Disqord.Rest/Extensions/RestClientExtensions.Emoji.cs
@@ -16,8 +16,8 @@ public static partial class RestClientExtensions
         Snowflake applicationId,
         IRestRequestOptions? options = null, CancellationToken cancellationToken = default)
     {
-        var models = await client.ApiClient.FetchApplicationEmojisAsync(applicationId, options, cancellationToken).ConfigureAwait(false);
-        return models.ToReadOnlyList((client, applicationId), static (model, state) =>
+        var model = await client.ApiClient.FetchApplicationEmojisAsync(applicationId, options, cancellationToken).ConfigureAwait(false);
+        return model.Items.ToReadOnlyList((client, applicationId), static (model, state) =>
         {
             var (client, applicationId) = state;
             return new TransientApplicationEmoji(client, applicationId, model);


### PR DESCRIPTION
## Description

- Implemented the following endpoints:
  - [List Application Emojis](https://discord.com/developers/docs/resources/emoji#list-application-emojis)
  - [Get Application Emoji](https://discord.com/developers/docs/resources/emoji#get-application-emoji)
  - [Create Application Emoji](https://discord.com/developers/docs/resources/emoji#create-application-emoji)
  - [Modify Application Emoji](https://discord.com/developers/docs/resources/emoji#modify-application-emoji)
  - [Delete Application Emoji](https://discord.com/developers/docs/resources/emoji#delete-application-emoji)
- Adds `IApplicationEntity` interface for future-proofing any further entities that can be created, managed, etc. by an application, currently only consumed by `IApplicationEmoji`.

## Checklist

[//]: # "Put an x in [ ] to check the checkbox, e.g. [x]"

- [ ] I discussed this PR with the maintainer(s) prior to opening it.
- [x] I read the [contributing guidelines](https://github.com/Quahu/Disqord/blob/master/.github/CONTRIBUTING.md).
- [x] I tested the changes in this PR.
