### PR TITLE
Include the executed route in RestApiException

### DIFF
--- a/src/Disqord.Rest.Api/Default/DefaultRestApiClient.cs
+++ b/src/Disqord.Rest.Api/Default/DefaultRestApiClient.cs
@@ -99,7 +99,7 @@ public class DefaultRestApiClient : IRestApiClient
                 return responseStream;
 
             if (statusCode > 499 && statusCode < 600)
-                throw new RestApiException(response.HttpResponse, response.HttpResponse.ReasonPhrase, null);
+                throw new RestApiException(route, response.HttpResponse, response.HttpResponse.ReasonPhrase, null);
 
             RestApiErrorJsonModel? errorModel = null;
             try
@@ -115,7 +115,7 @@ public class DefaultRestApiClient : IRestApiClient
                 await responseStream.DisposeAsync().ConfigureAwait(false);
             }
 
-            throw new RestApiException(response.HttpResponse, response.HttpResponse.ReasonPhrase, errorModel);
+            throw new RestApiException(route, response.HttpResponse, response.HttpResponse.ReasonPhrase, errorModel);
         }
     }
 }


### PR DESCRIPTION
## Description

At the present moment, due to inlining hiding the method calling InternalExecuteAsync from the stack trace, it is difficult to discern at a glance which REST API route was responsible for generating a RestApiException. This PR exposes an `IFormattedRoute` property on RestApiException, granting bot developers more access to finding the route cause of an API exception on their end.

To note, while `IFormattedRoute` is the type I chose to include for more granular control, only the `IFormattableRoute` is exposed when it comes to generating the exception message, to avoid exposing potentially sensitive information in logs:
```
Failed to execute route Patch|channels/{0:channel_id}.
```
The route is formatted identically to how the verbose/debug logs format for rate-limit buckets are formatted. I originally formatted it as `PATCH channels/{0:channel_id}`, as I think it looks better, but for consistency I chose to keep it the same.

## Checklist

[//]: # "Put an x in [ ] to check the checkbox, e.g. [x]"

- [x] I discussed this PR with the maintainer(s) prior to opening it.
- [x] I read the [contributing guidelines](https://github.com/Quahu/Disqord/blob/master/.github/CONTRIBUTING.md).
- [x] I tested the changes in this PR.
