### PR TITLE
Add support for message snapshots (forwarding)

### DIFF
--- a/src/Disqord.Core/Entities/Core/Message/User/IMessageReference.cs
+++ b/src/Disqord.Core/Entities/Core/Message/User/IMessageReference.cs
@@ -6,6 +6,11 @@
 public interface IMessageReference : IChannelEntity, IPossiblyGuildEntity
 {
     /// <summary>
+    ///     Gets the reference type of the referenced message.
+    /// </summary>
+    MessageReferenceType Type { get; }
+    
+    /// <summary>
     ///     Gets the ID of the referenced message.
     /// </summary>
     Snowflake? MessageId { get; }

--- a/src/Disqord.Core/Entities/Core/Message/User/IMessageSnapshot.cs
+++ b/src/Disqord.Core/Entities/Core/Message/User/IMessageSnapshot.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Disqord;
+
+public interface IMessageSnapshot : IEntity
+{
+    /// <summary>
+    ///     Gets the <see cref="UserMessageType"/> of this message snapshot.
+    /// </summary>
+    UserMessageType Type { get; }
+    
+    /// <summary>
+    ///     Gets the content of this message snapshot.
+    /// </summary>
+    string Content { get; }
+    
+    /// <summary>
+    ///     Gets the mentioned users of this message snapshot.
+    /// </summary>
+    IReadOnlyList<IUser> MentionedUsers { get; }
+    
+    /// <summary>
+    ///     Gets the mentioned role IDs of this message snapshot.
+    /// </summary>
+    IReadOnlyList<Snowflake> MentionedRoleIds { get; }
+    
+    /// <summary>
+    ///     Gets the attachments of this message snapshot.
+    /// </summary>
+    IReadOnlyList<IAttachment> Attachments { get; }
+
+    /// <summary>
+    ///     Gets the embeds of this message snapshot.
+    /// </summary>
+    IReadOnlyList<IEmbed> Embeds { get; }
+    
+    /// <summary>
+    ///     Gets the timestamp of when the snapshotted message was created.
+    /// </summary>
+    DateTimeOffset Timestamp { get; }
+
+    /// <summary>
+    ///     Gets the edit date of this message snapshot.
+    /// </summary>
+    DateTimeOffset? EditedAt { get; }
+    
+    /// <summary>
+    ///     Gets the flags of this message snapshot.
+    /// </summary>
+    MessageFlags Flags { get; }
+    
+    /// <summary>
+    ///     Gets the stickers sent with this message snapshot.
+    /// </summary>
+    IReadOnlyList<IMessageSticker> Stickers { get; }
+    
+    /// <summary>
+    ///     Gets the components of this message snapshot.
+    /// </summary>
+    IReadOnlyList<IRowComponent> Components { get; }
+}

--- a/src/Disqord.Core/Entities/Core/Message/User/IUserMessage.cs
+++ b/src/Disqord.Core/Entities/Core/Message/User/IUserMessage.cs
@@ -120,7 +120,7 @@ public interface IUserMessage : IMessage
     IPoll? Poll { get; }
     
     /// <summary>
-    ///     Gets the message snapshots referenced (forwarded) by this message.
+    ///     Gets the message snapshots of this message.
     /// </summary>
-    IReadOnlyList<IMessageSnapshot> MessageSnapshots { get; }
+    IReadOnlyList<IMessageSnapshot> Snapshots { get; }
 }

--- a/src/Disqord.Core/Entities/Core/Message/User/IUserMessage.cs
+++ b/src/Disqord.Core/Entities/Core/Message/User/IUserMessage.cs
@@ -118,4 +118,9 @@ public interface IUserMessage : IMessage
     ///     Gets the poll of this message.
     /// </summary>
     IPoll? Poll { get; }
+    
+    /// <summary>
+    ///     Gets the message snapshots referenced (forwarded) by this message.
+    /// </summary>
+    IReadOnlyList<IMessageSnapshot> MessageSnapshots { get; }
 }

--- a/src/Disqord.Core/Entities/Local/Message/Extensions/LocalMessageReferenceExtensions.cs
+++ b/src/Disqord.Core/Entities/Local/Message/Extensions/LocalMessageReferenceExtensions.cs
@@ -8,6 +8,13 @@ namespace Disqord;
 [EditorBrowsable(EditorBrowsableState.Never)]
 public static class LocalMessageReferenceExtensions
 {
+    public static TMessageReference WithType<TMessageReference>(this TMessageReference messageReference, MessageReferenceType type)
+        where TMessageReference : LocalMessageReference
+    {
+        messageReference.Type = type;
+        return messageReference;
+    }
+    
     /// <summary>
     ///     Sets the ID of the referenced message.
     /// </summary>

--- a/src/Disqord.Core/Entities/Local/Message/LocalMessageReference.cs
+++ b/src/Disqord.Core/Entities/Local/Message/LocalMessageReference.cs
@@ -13,9 +13,9 @@ public class LocalMessageReference : ILocalConstruct<LocalMessageReference>, IJs
     ///     Gets or sets the type of way this message will be referenced.
     /// </summary>
     /// <remarks>
-    ///     This property defaults to <see cref="MessageReferenceType.Reply"/>.
+    ///     This property defaults to <see cref="MessageReferenceType.Default"/>.
     /// </remarks>
-    public Optional<MessageReferenceType> Type { get; set; } = MessageReferenceType.Reply;
+    public Optional<MessageReferenceType> Type { get; set; } = MessageReferenceType.Default;
     
     /// <summary>
     ///     Gets or sets the ID of the referenced message.

--- a/src/Disqord.Core/Entities/Local/Message/LocalMessageReference.cs
+++ b/src/Disqord.Core/Entities/Local/Message/LocalMessageReference.cs
@@ -10,6 +10,14 @@ namespace Disqord;
 public class LocalMessageReference : ILocalConstruct<LocalMessageReference>, IJsonConvertible<MessageReferenceJsonModel>
 {
     /// <summary>
+    ///     Gets or sets the type of way this message will be referenced.
+    /// </summary>
+    /// <remarks>
+    ///     This property defaults to <see cref="MessageReferenceType.Reply"/>.
+    /// </remarks>
+    public Optional<MessageReferenceType> Type { get; set; } = MessageReferenceType.Reply;
+    
+    /// <summary>
     ///     Gets or sets the ID of the referenced message.
     /// </summary>
     /// <remarks>
@@ -65,6 +73,7 @@ public class LocalMessageReference : ILocalConstruct<LocalMessageReference>, IJs
     {
         return new MessageReferenceJsonModel
         {
+            Type = Type,
             MessageId = MessageId,
             ChannelId = ChannelId,
             GuildId = GuildId,
@@ -87,6 +96,7 @@ public class LocalMessageReference : ILocalConstruct<LocalMessageReference>, IJs
     {
         return new LocalMessageReference
         {
+            Type = reference.Type,
             MessageId = Optional.FromNullable(reference.MessageId),
             ChannelId = reference.ChannelId,
             GuildId = Optional.FromNullable(reference.GuildId)

--- a/src/Disqord.Core/Entities/Transient/Message/TransientMessage.cs
+++ b/src/Disqord.Core/Entities/Transient/Message/TransientMessage.cs
@@ -15,7 +15,7 @@ public abstract class TransientMessage : TransientClientEntity<MessageJsonModel>
     public Snowflake ChannelId => Model.ChannelId;
 
     /// <inheritdoc/>
-    public IUser Author => _author ??= new TransientUser(Client, Model.Author);
+    public IUser Author => _author ??= new TransientUser(Client, Model.Author.Value);
 
     private IUser? _author;
 

--- a/src/Disqord.Core/Entities/Transient/Message/User/TransientMessageReference.cs
+++ b/src/Disqord.Core/Entities/Transient/Message/User/TransientMessageReference.cs
@@ -6,6 +6,9 @@ namespace Disqord;
 public class TransientMessageReference : TransientEntity<MessageReferenceJsonModel>, IMessageReference
 {
     /// <inheritdoc/>
+    public MessageReferenceType Type => Model.Type.GetValueOrNullable() ?? MessageReferenceType.Reply;
+    
+    /// <inheritdoc/>
     public Snowflake? MessageId => Model.MessageId.GetValueOrNullable();
 
     /// <inheritdoc/>

--- a/src/Disqord.Core/Entities/Transient/Message/User/TransientMessageReference.cs
+++ b/src/Disqord.Core/Entities/Transient/Message/User/TransientMessageReference.cs
@@ -6,7 +6,7 @@ namespace Disqord;
 public class TransientMessageReference : TransientEntity<MessageReferenceJsonModel>, IMessageReference
 {
     /// <inheritdoc/>
-    public MessageReferenceType Type => Model.Type.GetValueOrNullable() ?? MessageReferenceType.Reply;
+    public MessageReferenceType Type => Model.Type.GetValueOrNullable() ?? MessageReferenceType.Default;
     
     /// <inheritdoc/>
     public Snowflake? MessageId => Model.MessageId.GetValueOrNullable();

--- a/src/Disqord.Core/Entities/Transient/Message/User/TransientMessageSnapshot.cs
+++ b/src/Disqord.Core/Entities/Transient/Message/User/TransientMessageSnapshot.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections.Generic;
+using Disqord.Models;
+using Qommon.Collections.ReadOnly;
+
+namespace Disqord;
+
+public class TransientMessageSnapshot : TransientClientEntity<MessageSnapshotJsonModel>, IMessageSnapshot
+{
+    /// <inheritdoc/>
+    public UserMessageType Type => Model.Message.Type;
+
+    /// <inheritdoc/>
+    public string Content => Model.Message.Content;
+    
+    /// <inheritdoc/>
+    public IReadOnlyList<IUser> MentionedUsers => _mentionedUsers ??= Model.Message.Mentions.ToReadOnlyList(Client, (model, client) => new TransientUser(client, model));
+
+    private IReadOnlyList<IUser>? _mentionedUsers;
+
+    /// <inheritdoc/>
+    public IReadOnlyList<Snowflake> MentionedRoleIds => Model.Message.MentionRoles;
+    
+    /// <inheritdoc/>
+    public IReadOnlyList<IAttachment> Attachments => _attachments ??= Model.Message.Attachments.ToReadOnlyList(model => new TransientAttachment(model));
+
+    private IReadOnlyList<IAttachment>? _attachments;
+    
+    /// <inheritdoc/>
+    public IReadOnlyList<IEmbed> Embeds => _embeds ??= Model.Message.Embeds.ToReadOnlyList(model => new TransientEmbed(model));
+
+    private IReadOnlyList<IEmbed>? _embeds;
+    
+    /// <inheritdoc/>
+    public DateTimeOffset Timestamp { get; }
+    
+    /// <inheritdoc/>
+    public DateTimeOffset? EditedAt { get; }
+    
+    /// <inheritdoc/>
+    public MessageFlags Flags { get; }
+    
+    /// <inheritdoc/>
+    public IReadOnlyList<IMessageSticker> Stickers
+    {
+        get
+        {
+            if (!Model.Message.StickerItems.HasValue)
+                return Array.Empty<IMessageSticker>();
+
+            return _stickers ??= Model.Message.StickerItems.Value.ToReadOnlyList(model => new TransientMessageSticker(model));
+        }
+    }
+
+    private IReadOnlyList<IMessageSticker>? _stickers;
+    
+    public IReadOnlyList<IRowComponent> Components
+    {
+        get
+        {
+            if (!Model.Message.Components.HasValue)
+                return Array.Empty<IRowComponent>();
+
+            return _components ??= Model.Message.Components.Value.ToReadOnlyList(Client, (model, client) => new TransientRowComponent(client, model));
+        }
+    }
+    private IReadOnlyList<IRowComponent>? _components;
+    
+    public TransientMessageSnapshot(IClient client, MessageSnapshotJsonModel model) 
+        : base(client, model)
+    { }
+}

--- a/src/Disqord.Core/Entities/Transient/Message/User/TransientUserMessage.cs
+++ b/src/Disqord.Core/Entities/Transient/Message/User/TransientUserMessage.cs
@@ -125,13 +125,24 @@ public class TransientUserMessage : TransientMessage, IUserMessage
             return _stickers ??= Model.StickerItems.Value.ToReadOnlyList(model => new TransientMessageSticker(model));
         }
     }
-
     private IReadOnlyList<IMessageSticker>? _stickers;
 
     /// <inheritdoc/>
     public IPoll? Poll => _poll ??= Optional.ConvertOrDefault(Model.Poll, poll => new TransientPoll(poll));
 
     private IPoll? _poll;
+
+    public IReadOnlyList<IMessageSnapshot> MessageSnapshots
+    {
+        get
+        {
+            if (!Model.MessageSnapshots.HasValue)
+                return Array.Empty<IMessageSnapshot>();
+
+            return _messageSnapshots ??= Model.MessageSnapshots.Value.ToReadOnlyList(Client, (model, client) => new TransientMessageSnapshot(client, model));
+        }
+    }
+    private IReadOnlyList<IMessageSnapshot>? _messageSnapshots;
 
     public TransientUserMessage(IClient client, MessageJsonModel model)
         : base(client, model)

--- a/src/Disqord.Core/Entities/Transient/Message/User/TransientUserMessage.cs
+++ b/src/Disqord.Core/Entities/Transient/Message/User/TransientUserMessage.cs
@@ -132,7 +132,7 @@ public class TransientUserMessage : TransientMessage, IUserMessage
 
     private IPoll? _poll;
 
-    public IReadOnlyList<IMessageSnapshot> MessageSnapshots
+    public IReadOnlyList<IMessageSnapshot> Snapshots
     {
         get
         {

--- a/src/Disqord.Core/Enums/MessageReferenceType.cs
+++ b/src/Disqord.Core/Enums/MessageReferenceType.cs
@@ -8,7 +8,7 @@ public enum MessageReferenceType
     /// <summary>
     ///     A standard reference used by replies.
     /// </summary>
-    Reply = 0,
+    Default = 0,
     
     /// <summary>
     ///     A reference used to point to a message at a point in time.

--- a/src/Disqord.Core/Enums/MessageReferenceType.cs
+++ b/src/Disqord.Core/Enums/MessageReferenceType.cs
@@ -1,0 +1,17 @@
+﻿namespace Disqord;
+
+/// <summary>
+///     Represents the type of a message reference.
+/// </summary>
+public enum MessageReferenceType
+{
+    /// <summary>
+    ///     A standard reference used by replies.
+    /// </summary>
+    Reply = 0,
+    
+    /// <summary>
+    ///     A reference used to point to a message at a point in time.
+    /// </summary>
+    Forward = 1
+}

--- a/src/Disqord.Core/Models/Message/MessageJsonModel.cs
+++ b/src/Disqord.Core/Models/Message/MessageJsonModel.cs
@@ -17,7 +17,7 @@ public class MessageJsonModel : JsonModel
     public Optional<Snowflake> GuildId;
 
     [JsonProperty("author")]
-    public UserJsonModel Author = null!;
+    public Optional<UserJsonModel> Author;
 
     [JsonProperty("member")]
     public Optional<MemberJsonModel> Member;
@@ -78,6 +78,9 @@ public class MessageJsonModel : JsonModel
 
     [JsonProperty("message_reference")]
     public Optional<MessageReferenceJsonModel> MessageReference;
+
+    [JsonProperty("message_snapshots")]
+    public Optional<MessageSnapshotJsonModel[]> MessageSnapshots;
 
     [JsonProperty("flags")]
     public Optional<MessageFlags> Flags;

--- a/src/Disqord.Core/Models/Message/MessageReferenceJsonModel.cs
+++ b/src/Disqord.Core/Models/Message/MessageReferenceJsonModel.cs
@@ -5,6 +5,9 @@ namespace Disqord.Models;
 
 public class MessageReferenceJsonModel : JsonModel
 {
+    [JsonProperty("type")]
+    public Optional<MessageReferenceType> Type;
+    
     [JsonProperty("message_id")]
     public Optional<Snowflake> MessageId;
 

--- a/src/Disqord.Core/Models/Message/MessageSnapshotJsonModel.cs
+++ b/src/Disqord.Core/Models/Message/MessageSnapshotJsonModel.cs
@@ -1,0 +1,9 @@
+﻿using Disqord.Serialization.Json;
+
+namespace Disqord.Models;
+
+public class MessageSnapshotJsonModel : JsonModel
+{
+    [JsonProperty("message")]
+    public MessageJsonModel Message = null!;
+}

--- a/src/Disqord.Gateway/Entities/Cached/Message/CachedMessage.cs
+++ b/src/Disqord.Gateway/Entities/Cached/Message/CachedMessage.cs
@@ -53,7 +53,7 @@ public abstract class CachedMessage : CachedSnowflakeEntity, IGatewayMessage,
             }
             else
             {
-                _author = new TransientUser(Client, model.Author);
+                _author = new TransientUser(Client, model.Author.Value);
             }
         }
 
@@ -72,7 +72,7 @@ public abstract class CachedMessage : CachedSnowflakeEntity, IGatewayMessage,
             }
             else
             {
-                _author = new TransientUser(Client, model.Author);
+                _author = new TransientUser(Client, model.Author.Value);
             }
         }
 

--- a/src/Disqord.Gateway/Entities/Cached/Message/User/CachedUserMessage.cs
+++ b/src/Disqord.Gateway/Entities/Cached/Message/User/CachedUserMessage.cs
@@ -67,7 +67,7 @@ public class CachedUserMessage : CachedMessage, IGatewayUserMessage, IJsonUpdata
     /// <inheritdoc/>
     public IPoll? Poll { get; private set; }
 
-    public IReadOnlyList<IMessageSnapshot> MessageSnapshots { get; private set; } = null!;
+    public IReadOnlyList<IMessageSnapshot> Snapshots { get; private set; } = null!;
 
     public CachedUserMessage(IGatewayClient client, CachedMember? author, MessageJsonModel model)
         : base(client, author, model)
@@ -98,7 +98,7 @@ public class CachedUserMessage : CachedMessage, IGatewayUserMessage, IJsonUpdata
         Components = Optional.ConvertOrDefault(model.Components, (models, client) => models.ToReadOnlyList(client, (model, client) => new TransientRowComponent(client, model) as IRowComponent), Client) ?? Array.Empty<IRowComponent>();
         Stickers = Optional.ConvertOrDefault(model.StickerItems, models => models.ToReadOnlyList(model => new TransientMessageSticker(model) as IMessageSticker), Array.Empty<IMessageSticker>());
         Poll = Optional.ConvertOrDefault(model.Poll, model => new TransientPoll(model));
-        MessageSnapshots = Optional.ConvertOrDefault(model.MessageSnapshots, models => models.ToReadOnlyList(Client, (model, client) => new TransientMessageSnapshot(client, model) as IMessageSnapshot)) ?? Array.Empty<IMessageSnapshot>();
+        Snapshots = Optional.ConvertOrDefault(model.MessageSnapshots, models => models.ToReadOnlyList(Client, (model, client) => new TransientMessageSnapshot(client, model) as IMessageSnapshot)) ?? Array.Empty<IMessageSnapshot>();
     }
 
     public void Update(MessageUpdateJsonModel model)

--- a/src/Disqord.Gateway/Entities/Cached/Message/User/CachedUserMessage.cs
+++ b/src/Disqord.Gateway/Entities/Cached/Message/User/CachedUserMessage.cs
@@ -67,6 +67,8 @@ public class CachedUserMessage : CachedMessage, IGatewayUserMessage, IJsonUpdata
     /// <inheritdoc/>
     public IPoll? Poll { get; private set; }
 
+    public IReadOnlyList<IMessageSnapshot> MessageSnapshots { get; private set; } = null!;
+
     public CachedUserMessage(IGatewayClient client, CachedMember? author, MessageJsonModel model)
         : base(client, author, model)
     {
@@ -96,6 +98,7 @@ public class CachedUserMessage : CachedMessage, IGatewayUserMessage, IJsonUpdata
         Components = Optional.ConvertOrDefault(model.Components, (models, client) => models.ToReadOnlyList(client, (model, client) => new TransientRowComponent(client, model) as IRowComponent), Client) ?? Array.Empty<IRowComponent>();
         Stickers = Optional.ConvertOrDefault(model.StickerItems, models => models.ToReadOnlyList(model => new TransientMessageSticker(model) as IMessageSticker), Array.Empty<IMessageSticker>());
         Poll = Optional.ConvertOrDefault(model.Poll, model => new TransientPoll(model));
+        MessageSnapshots = Optional.ConvertOrDefault(model.MessageSnapshots, models => models.ToReadOnlyList(Client, (model, client) => new TransientMessageSnapshot(client, model) as IMessageSnapshot)) ?? Array.Empty<IMessageSnapshot>();
     }
 
     public void Update(MessageUpdateJsonModel model)

--- a/src/Disqord.Gateway/Entities/Transient/Message/TransientGatewayMessage.cs
+++ b/src/Disqord.Gateway/Entities/Transient/Message/TransientGatewayMessage.cs
@@ -25,14 +25,14 @@ public abstract class TransientGatewayMessage : TransientGatewayClientEntity<Mes
             var guildId = Model.GuildId;
             if (!guildId.HasValue || !Model.Member.HasValue)
             {
-                var user = Client.GetUser(Model.Author.Id);
+                var user = Client.GetUser(Model.Author.Value.Id);
                 if (user != null)
                     return user;
 
-                return _author ??= new TransientUser(Client, Model.Author);
+                return _author ??= new TransientUser(Client, Model.Author.Value);
             }
 
-            var member = Client.GetMember(guildId.Value, Model.Author.Id);
+            var member = Client.GetMember(guildId.Value, Model.Author.Value.Id);
             if (member != null)
                 return member;
 

--- a/src/Disqord.Gateway/Entities/Transient/Message/User/TransientGatewayUserMessage.cs
+++ b/src/Disqord.Gateway/Entities/Transient/Message/User/TransientGatewayUserMessage.cs
@@ -105,6 +105,18 @@ public class TransientGatewayUserMessage : TransientGatewayMessage, IGatewayUser
     public IPoll? Poll => _poll ??= Optional.ConvertOrDefault(Model.Poll, poll => new TransientPoll(poll));
 
     private IPoll? _poll;
+    
+    public IReadOnlyList<IMessageSnapshot> MessageSnapshots
+    {
+        get
+        {
+            if (!Model.MessageSnapshots.HasValue)
+                return Array.Empty<IMessageSnapshot>();
+
+            return _messageSnapshots ??= Model.MessageSnapshots.Value.ToReadOnlyList(Client, (model, client) => new TransientMessageSnapshot(client, model));
+        }
+    }
+    private IReadOnlyList<IMessageSnapshot>? _messageSnapshots;
 
     public TransientGatewayUserMessage(IClient client, MessageJsonModel model)
         : base(client, model)

--- a/src/Disqord.Gateway/Entities/Transient/Message/User/TransientGatewayUserMessage.cs
+++ b/src/Disqord.Gateway/Entities/Transient/Message/User/TransientGatewayUserMessage.cs
@@ -106,7 +106,7 @@ public class TransientGatewayUserMessage : TransientGatewayMessage, IGatewayUser
 
     private IPoll? _poll;
     
-    public IReadOnlyList<IMessageSnapshot> MessageSnapshots
+    public IReadOnlyList<IMessageSnapshot> Snapshots
     {
         get
         {


### PR DESCRIPTION
## Description
https://discord.com/developers/docs/resources/message#message-reference-content-attribution-forwards

This PR adds support for receiving and sending message snapshots (forwarded messages).

Notable changes:
- `MessageReferenceType` enum added, with values Reply (0) and Forward (1)
- `IMessageReference` now contains a `MessageReferenceType` Type property
- Added `IMessageSnapshot` interface and Transient implementation - this type is very similar to `IMessage` but lacks an author property. I'm unsure if it would be worth it to abstract common data between the two types further, so I elected not to.
- `MessageJsonModel` is used as the model for snapshots - this introduces a "breaking" change where Author is optional (snapshots lack an author). Several models were adjusted where Author is known to have a value to simply use `.Value` now.

Received forwarded messages can be found via `IUserMessage#MessageSnapshots`, and can be sent via a LocalMessageReference with Type: Forward (not supported in app command responses)

## Checklist

- [ ] I discussed this PR with the maintainer(s) prior to opening it.
- [x] I read the [contributing guidelines](https://github.com/Quahu/Disqord/blob/master/.github/CONTRIBUTING.md).
- [x] I tested the changes in this PR.