### PR TITLE
Add with_response support for interactions

### DIFF
--- a/.github/actions/dotnet/action.yml
+++ b/.github/actions/dotnet/action.yml
@@ -12,7 +12,7 @@ runs:
     - name: Set up .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 9.0.x
     - name: Restore
       run: dotnet restore $Env:SOLUTION_PATH
       shell: pwsh

--- a/src/Disqord.Bot/Bot/Base/Callbacks/DiscordBotBase.Callbacks.cs
+++ b/src/Disqord.Bot/Bot/Base/Callbacks/DiscordBotBase.Callbacks.cs
@@ -224,7 +224,7 @@ public abstract partial class DiscordBotBase
         {
             if (message is LocalInteractionMessageResponse localInteractionMessageResponse)
             {
-                task = interactionContext.SendMessageAsync(localInteractionMessageResponse, false, cancellationToken: context.CancellationToken);
+                task = interactionContext.SendMessageAsync(localInteractionMessageResponse, cancellationToken: context.CancellationToken);
             }
             else
             {

--- a/src/Disqord.Bot/Commands/Contexts/Extensions/DiscordInteractionCommandContextExtensions.cs
+++ b/src/Disqord.Bot/Commands/Contexts/Extensions/DiscordInteractionCommandContextExtensions.cs
@@ -1,4 +1,3 @@
-using System.ComponentModel;
 using System.Threading;
 using System.Threading.Tasks;
 using Disqord.Rest;
@@ -8,11 +7,9 @@ namespace Disqord.Bot.Commands.Interaction;
 /// <summary>
 ///     Represents <see cref="IDiscordInteractionCommandContext"/> extensions.
 /// </summary>
-[EditorBrowsable(EditorBrowsableState.Never)]
-public static class DiscordInteractionCommandContextExtensions
+internal static class DiscordInteractionCommandContextExtensions
 {
     internal static Task SendMessageAsync(this IDiscordInteractionCommandContext context, LocalInteractionMessageResponse message,
-        bool fetchMessage,
         IRestRequestOptions? options = null,
         CancellationToken cancellationToken = default)
     {
@@ -20,16 +17,7 @@ public static class DiscordInteractionCommandContextExtensions
         var response = interaction.Response();
         if (!response.HasResponded)
         {
-            static async Task<IUserMessage> SendMessageWithResult(InteractionResponseHelper response, LocalInteractionMessageResponse message,
-                IRestRequestOptions? options, CancellationToken cancellationToken)
-            {
-                await response.SendMessageAsync(message, options, cancellationToken).ConfigureAwait(false);
-                return await response.Interaction.Followup().FetchResponseAsync(options, cancellationToken).ConfigureAwait(false);
-            }
-
-            return fetchMessage
-                ? SendMessageWithResult(response, message, options, cancellationToken)
-                : response.SendMessageAsync(message, options, cancellationToken);
+            return response.SendMessageAsync(message, options, cancellationToken);
         }
 
         var followup = interaction.Followup();

--- a/src/Disqord.Bot/Commands/Results/DiscordCommandResult`2.cs
+++ b/src/Disqord.Bot/Commands/Results/DiscordCommandResult`2.cs
@@ -10,5 +10,10 @@ public abstract class DiscordCommandResult<TContext, TResult> : DiscordCommandRe
         : base(context)
     { }
 
+    public override Task ExecuteAsync(CancellationToken cancellationToken = default)
+    {
+        return ExecuteWithResultAsync(cancellationToken);
+    }
+
     public abstract Task<TResult> ExecuteWithResultAsync(CancellationToken cancellationToken = default);
 }

--- a/src/Disqord.Bot/Commands/Results/Interactions/DiscordInteractionResponseCommandResult.cs
+++ b/src/Disqord.Bot/Commands/Results/Interactions/DiscordInteractionResponseCommandResult.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Qommon;
@@ -10,17 +11,15 @@ public class DiscordInteractionResponseCommandResult : DiscordResponseCommandRes
         : base(context, message)
     { }
 
-    public override Task ExecuteAsync(CancellationToken cancellationToken = default)
+    public new TaskAwaiter<IUserMessage> GetAwaiter()
     {
-        var context = Guard.IsAssignableToType<IDiscordInteractionCommandContext>(Context);
-        var message = Guard.IsAssignableToType<LocalInteractionMessageResponse>(Message);
-        return context.SendMessageAsync(message, false, cancellationToken: cancellationToken);
+        return ExecuteWithResultAsync().GetAwaiter();
     }
 
     public override Task<IUserMessage> ExecuteWithResultAsync(CancellationToken cancellationToken = default)
     {
         var context = Guard.IsAssignableToType<IDiscordInteractionCommandContext>(Context);
         var message = Guard.IsAssignableToType<LocalInteractionMessageResponse>(Message);
-        return Guard.IsAssignableToType<Task<IUserMessage>>(context.SendMessageAsync(message, true, cancellationToken: cancellationToken));
+        return Guard.IsAssignableToType<Task<IUserMessage>>(context.SendMessageAsync(message, cancellationToken: cancellationToken));
     }
 }

--- a/src/Disqord.Rest.Api/Models/CallbackInteractionJsonModel.cs
+++ b/src/Disqord.Rest.Api/Models/CallbackInteractionJsonModel.cs
@@ -1,0 +1,21 @@
+﻿using Disqord.Serialization.Json;
+
+namespace Disqord.Rest.Api.Models;
+
+public class CallbackInteractionJsonModel : JsonModel
+{
+    [JsonProperty("id")]
+    public Snowflake Id;
+
+    [JsonProperty("type")]
+    public InteractionType Type;
+
+    [JsonProperty("response_message_id")]
+    public Snowflake? ResponseMessageId;
+
+    [JsonProperty("response_message_loading")]
+    public bool? ResponseMessageLoading;
+
+    [JsonProperty("response_message_ephemeral")]
+    public bool? ResponseMessageEphemeral;
+}

--- a/src/Disqord.Rest.Api/Models/InteractionCallbackResourceJsonModel.cs
+++ b/src/Disqord.Rest.Api/Models/InteractionCallbackResourceJsonModel.cs
@@ -1,0 +1,13 @@
+﻿using Disqord.Models;
+using Disqord.Serialization.Json;
+
+namespace Disqord.Rest.Api.Models;
+
+public class InteractionCallbackResourceJsonModel : JsonModel
+{
+    [JsonProperty("type")]
+    public InteractionResponseType Type;
+
+    [JsonProperty("message")]
+    public MessageJsonModel? Message;
+}

--- a/src/Disqord.Rest.Api/Models/InteractionCallbackResponseJsonModel.cs
+++ b/src/Disqord.Rest.Api/Models/InteractionCallbackResponseJsonModel.cs
@@ -1,0 +1,12 @@
+﻿using Disqord.Serialization.Json;
+
+namespace Disqord.Rest.Api.Models;
+
+public class InteractionCallbackResponseJsonModel : JsonModel
+{
+    [JsonProperty("interaction")]
+    public CallbackInteractionJsonModel Interaction = null!;
+
+    [JsonProperty("resource")]
+    public InteractionCallbackResourceJsonModel? Resource;
+}

--- a/src/Disqord.Rest/Entities/Core/Interactions/ICallbackInteraction.cs
+++ b/src/Disqord.Rest/Entities/Core/Interactions/ICallbackInteraction.cs
@@ -1,0 +1,27 @@
+﻿namespace Disqord.Rest;
+
+/// <summary>
+///     Represents the callback interaction of <see cref="IInteractionCallbackResponse"/>.
+/// </summary>
+public interface ICallbackInteraction : IIdentifiableEntity
+{
+    /// <summary>
+    ///     Gets the type of the interaction.
+    /// </summary>
+    InteractionType Type { get; }
+
+    /// <summary>
+    ///     Gets the ID of the response message.
+    /// </summary>
+    Snowflake? ResponseMessageId { get; }
+
+    /// <summary>
+    ///     Gets whether the response message is "loading", i.e. whether it is deferred.
+    /// </summary>
+    bool? IsResponseMessageLoading { get; }
+
+    /// <summary>
+    ///     Gets whether the response message is ephemeral, i.e. only visible to the interaction author.
+    /// </summary>
+    bool? IsResponseMessageEphemeral { get; }
+}

--- a/src/Disqord.Rest/Entities/Core/Interactions/ICallbackResource.cs
+++ b/src/Disqord.Rest/Entities/Core/Interactions/ICallbackResource.cs
@@ -1,0 +1,11 @@
+﻿namespace Disqord.Rest;
+
+/// <summary>
+///     Represents the callback resource of <see cref="IInteractionCallbackResponse"/>.
+/// </summary>
+public interface ICallbackResource : IEntity
+{
+    InteractionResponseType Type { get; }
+
+    IUserMessage? Message { get; }
+}

--- a/src/Disqord.Rest/Entities/Core/Interactions/IInteractionCallbackResponse.cs
+++ b/src/Disqord.Rest/Entities/Core/Interactions/IInteractionCallbackResponse.cs
@@ -1,0 +1,18 @@
+﻿namespace Disqord.Rest;
+
+/// <summary>
+///     Represents the immediate interaction callback response from
+///     <see cref="RestClientExtensions.CreateInteractionResponseAsync(Disqord.Rest.IRestClient,Disqord.Snowflake,string,Disqord.ILocalInteractionResponse,bool,Disqord.Rest.IRestRequestOptions?,System.Threading.CancellationToken)"/>.
+/// </summary>
+public interface IInteractionCallbackResponse : IEntity
+{
+    /// <summary>
+    ///     Gets the interaction information of this response.
+    /// </summary>
+    ICallbackInteraction Interaction { get; }
+
+    /// <summary>
+    ///     Gets the interaction resource of this response.
+    /// </summary>
+    ICallbackResource? Resource { get; }
+}

--- a/src/Disqord.Rest/Entities/Transient/Interactions/TransientCallbackInteraction.cs
+++ b/src/Disqord.Rest/Entities/Transient/Interactions/TransientCallbackInteraction.cs
@@ -1,0 +1,22 @@
+﻿using Disqord.Rest.Api.Models;
+
+namespace Disqord.Rest;
+
+public class TransientCallbackInteraction(CallbackInteractionJsonModel model)
+    : TransientEntity<CallbackInteractionJsonModel>(model), ICallbackInteraction
+{
+    /// <inheritdoc/>
+    public Snowflake Id => Model.Id;
+
+    /// <inheritdoc/>
+    public InteractionType Type => Model.Type;
+
+    /// <inheritdoc/>
+    public Snowflake? ResponseMessageId => Model.ResponseMessageId;
+
+    /// <inheritdoc/>
+    public bool? IsResponseMessageLoading => Model.ResponseMessageLoading;
+
+    /// <inheritdoc/>
+    public bool? IsResponseMessageEphemeral => Model.ResponseMessageEphemeral;
+}

--- a/src/Disqord.Rest/Entities/Transient/Interactions/TransientCallbackResource.cs
+++ b/src/Disqord.Rest/Entities/Transient/Interactions/TransientCallbackResource.cs
@@ -1,0 +1,11 @@
+﻿using Disqord.Rest.Api.Models;
+
+namespace Disqord.Rest;
+
+public class TransientCallbackResource(IClient client, InteractionCallbackResourceJsonModel model)
+    : TransientEntity<InteractionCallbackResourceJsonModel>(model), ICallbackResource
+{
+    public InteractionResponseType Type => Model.Type;
+
+    public IUserMessage? Message => field ??= Model.Message != null ? new TransientUserMessage(client, Model.Message) : null;
+}

--- a/src/Disqord.Rest/Entities/Transient/Interactions/TransientInteractionCallbackResponse.cs
+++ b/src/Disqord.Rest/Entities/Transient/Interactions/TransientInteractionCallbackResponse.cs
@@ -1,0 +1,15 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using Disqord.Rest.Api.Models;
+
+namespace Disqord.Rest;
+
+public class TransientInteractionCallbackResponse(IClient client, InteractionCallbackResponseJsonModel model)
+    : TransientEntity<InteractionCallbackResponseJsonModel>(model), IInteractionCallbackResponse
+{
+    /// <inheritdoc/>
+    [field: MaybeNull]
+    public ICallbackInteraction Interaction => field ??= new TransientCallbackInteraction(Model.Interaction);
+
+    /// <inheritdoc/>
+    public ICallbackResource? Resource => field ??= Model.Resource != null ? new TransientCallbackResource(client, Model.Resource) : null;
+}

--- a/src/Disqord.Rest/Extensions/RestClientExtensions.Interactions.cs
+++ b/src/Disqord.Rest/Extensions/RestClientExtensions.Interactions.cs
@@ -6,30 +6,35 @@ using System.Threading.Tasks;
 using Disqord.Http;
 using Disqord.Models;
 using Disqord.Rest.Api;
+using Disqord.Rest.Api.Models;
 using Qommon;
 
 namespace Disqord.Rest;
 
 public static partial class RestClientExtensions
 {
-    public static Task CreateInteractionResponseAsync(this IRestClient client,
+    public static async Task<IInteractionCallbackResponse?> CreateInteractionResponseAsync(this IRestClient client,
         Snowflake interactionId, string interactionToken, ILocalInteractionResponse response,
+        bool withResponse,
         IRestRequestOptions? options = null, CancellationToken cancellationToken = default)
     {
         var content = response.ToContent(client.ApiClient.Serializer, out var attachments);
 
-        Task task;
+        Task<InteractionCallbackResponseJsonModel?> task;
         if (attachments.Count != 0)
         {
             var multipartContent = new AttachmentJsonPayloadRestRequestContent<CreateInitialInteractionResponseJsonRestRequestContent>(content, attachments);
-            task = client.ApiClient.CreateInitialInteractionResponseAsync(interactionId, interactionToken, multipartContent, options, cancellationToken);
+            task = client.ApiClient.CreateInitialInteractionResponseAsync(interactionId, interactionToken, multipartContent, withResponse, options, cancellationToken);
         }
         else
         {
-            task = client.ApiClient.CreateInitialInteractionResponseAsync(interactionId, interactionToken, content, options, cancellationToken);
+            task = client.ApiClient.CreateInitialInteractionResponseAsync(interactionId, interactionToken, content, withResponse, options, cancellationToken);
         }
 
-        return task;
+        var model = await task.ConfigureAwait(false);
+        return model != null
+            ? new TransientInteractionCallbackResponse(client, model)
+            : null;
     }
 
     public static async Task<IUserMessage> FetchInteractionResponseAsync(this IRestClient client,


### PR DESCRIPTION
## Description

Adds support for the `with_response` query parameter for interaction response creation.

Currently, this saves a request when doing:
```cs
await interaction.Response().SendMessageAsync(...);
var message = await interaction.Followup().FetchResponseAsync();
```
or
```cs
var message = await Response(...).WithResult();
```
<hr/>

These can be now written as:
```cs
var message = await interaction.Response().SendMessageAsync(...);
```
and
```cs
var message = await Response(...);
```
