### PR TITLE
Fix ModalSubmitInteraction Deserialization

### DIFF
--- a/src/Disqord.Core/Serialization/Json/Default/Converters/Polymorphic/ComponentConverter.cs
+++ b/src/Disqord.Core/Serialization/Json/Default/Converters/Polymorphic/ComponentConverter.cs
@@ -24,7 +24,7 @@ internal sealed class ComponentConverter : PolymorphicJsonConverter<BaseComponen
         }
 
         var componentType = GetComponentJsonModelType(type.Deserialize<ComponentType>(options));
-        var component = (BaseComponentJsonModel?) node.Deserialize(componentType, OptionsWithoutSelf);
+        var component = (BaseComponentJsonModel?) node.Deserialize(componentType, OptionsWithPreserve);
         Debug.Assert(component != null);
         return component;
     }

--- a/src/Disqord.Core/Serialization/Json/Default/Converters/Polymorphic/IPolymorphicJsonConverter.cs
+++ b/src/Disqord.Core/Serialization/Json/Default/Converters/Polymorphic/IPolymorphicJsonConverter.cs
@@ -5,4 +5,6 @@ namespace Disqord.Serialization.Json.Default;
 internal interface IPolymorphicJsonConverter
 {
     void SetOptionsWithoutSelf(JsonSerializerOptions options);
+    
+    void SetOptionsWithPreserve(JsonSerializerOptions options);
 }

--- a/src/Disqord.Core/Serialization/Json/Default/Converters/Polymorphic/PolymorphicJsonConverter.cs
+++ b/src/Disqord.Core/Serialization/Json/Default/Converters/Polymorphic/PolymorphicJsonConverter.cs
@@ -6,6 +6,7 @@ namespace Disqord.Serialization.Json.Default;
 internal abstract class PolymorphicJsonConverter<T> : JsonConverter<T>, IPolymorphicJsonConverter
 {
     public JsonSerializerOptions? OptionsWithoutSelf { get; private set; }
+    public JsonSerializerOptions? OptionsWithPreserve { get; private set; }
 
     protected JsonSerializerOptions GetPolymorphicOptions(object value, JsonSerializerOptions options)
     {
@@ -17,5 +18,10 @@ internal abstract class PolymorphicJsonConverter<T> : JsonConverter<T>, IPolymor
     public void SetOptionsWithoutSelf(JsonSerializerOptions options)
     {
         OptionsWithoutSelf = options;
+    }
+    
+    public void SetOptionsWithPreserve(JsonSerializerOptions options)
+    {
+        OptionsWithPreserve = options;
     }
 }

--- a/src/Disqord.Core/Serialization/Json/Default/DefaultJsonSerializer.cs
+++ b/src/Disqord.Core/Serialization/Json/Default/DefaultJsonSerializer.cs
@@ -65,9 +65,17 @@ public sealed class DefaultJsonSerializer : IJsonSerializer
 
             polymorphicOptions.Converters.RemoveAt(converterIndex);
             polymorphicOptions.MakeReadOnly();
+            
+            // Options for deserialization (with ReferenceHandler.Preserve and including the converter)
+            var preserveOptions = new JsonSerializerOptions(UnderlyingOptions)
+            {
+                ReferenceHandler = ReferenceHandler.Preserve
+            };
+            preserveOptions.MakeReadOnly();
 
             // Each polymorphic converter gets its own set of options which don't contain that converter.
             polymorphicConverter.SetOptionsWithoutSelf(polymorphicOptions);
+            polymorphicConverter.SetOptionsWithPreserve(preserveOptions);
         }
     }
 


### PR DESCRIPTION
## Description

- Implements a new `JsonSerializerOptions` property `OptionsWithPreserve` with self & `ReferenceHandler.Preserve` behavior
- Enables proper handling of circular references during stj deserialization


## Fixes

- Deserialization of ModalSubmitInteraction TextInputComponents

## Checklist

[//]: # "Put an x in [ ] to check the checkbox, e.g. [x]"

- [x] I discussed this PR with the maintainer(s) prior to opening it.
- [x] I read the [contributing guidelines](https://github.com/Quahu/Disqord/blob/master/.github/CONTRIBUTING.md).
- [x] I tested the changes in this PR.
