### PR TITLE
Add message component response support.

### DIFF
--- a/src/Disqord.Bot/Commands/ModuleBases/Interactions/DiscordInteractionModuleBase`1.cs
+++ b/src/Disqord.Bot/Commands/ModuleBases/Interactions/DiscordInteractionModuleBase`1.cs
@@ -56,6 +56,16 @@ public abstract class DiscordInteractionModuleBase<TContext> : DiscordModuleBase
         => Response(new LocalInteractionMessageResponse().WithContent(content).WithEmbeds(embeds));
 
     /// <summary>
+    ///     Returns a result that will respond in the context channel with the specified message components.
+    /// </summary>
+    /// <param name="components"> The message components to respond with. </param>
+    /// <returns>
+    ///     The created command result.
+    /// </returns>
+    protected virtual DiscordInteractionResponseCommandResult Response(params LocalComponent[] components)
+        => Response(new LocalInteractionMessageResponse().WithComponents(components));
+
+    /// <summary>
     ///     Returns a result that will respond in the context channel with the specified message.
     /// </summary>
     /// <param name="message"> The message to respond with. </param>

--- a/src/Disqord.Bot/Commands/ModuleBases/Text/DiscordTextModuleBase`1.cs
+++ b/src/Disqord.Bot/Commands/ModuleBases/Text/DiscordTextModuleBase`1.cs
@@ -44,6 +44,16 @@ public abstract class DiscordTextModuleBase<TContext> : DiscordModuleBase<TConte
     /// </returns>
     protected virtual DiscordTextResponseCommandResult Reply(string content, params LocalEmbed[] embeds)
         => Reply(new LocalMessage().WithContent(content).WithEmbeds(embeds));
+    
+    /// <summary>
+    ///     Returns a result that will reply in the context channel with the specified message components.
+    /// </summary>
+    /// <param name="components"> The message components to reply with. </param>
+    /// <returns>
+    ///     The created command result.
+    /// </returns>
+    protected virtual DiscordTextResponseCommandResult Reply(params LocalComponent[] components)
+        => Response(new LocalMessage().WithComponents(components).WithReply(Context.Message.Id, Context.ChannelId, Context.GuildId));
 
     /// <summary>
     ///     Returns a result that will reply to the context message with the specified message.
@@ -68,7 +78,7 @@ public abstract class DiscordTextModuleBase<TContext> : DiscordModuleBase<TConte
     /// <summary>
     ///     Returns a result that will respond in the context channel with the specified embeds.
     /// </summary>
-    /// <param name="embeds"> The embeds to reply with. </param>
+    /// <param name="embeds"> The embeds to respond with. </param>
     /// <returns>
     ///     The created command result.
     /// </returns>
@@ -78,18 +88,28 @@ public abstract class DiscordTextModuleBase<TContext> : DiscordModuleBase<TConte
     /// <summary>
     ///     Returns a result that will respond in the context channel with the specified content and embeds.
     /// </summary>
-    /// <param name="content"> The content to reply with. </param>
-    /// <param name="embeds"> The embeds to reply with. </param>
+    /// <param name="content"> The content to respond with. </param>
+    /// <param name="embeds"> The embeds to respond with. </param>
     /// <returns>
     ///     The created command result.
     /// </returns>
     protected virtual DiscordTextResponseCommandResult Response(string content, params LocalEmbed[] embeds)
         => Response(new LocalMessage().WithContent(content).WithEmbeds(embeds));
+    
+    /// <summary>
+    ///     Returns a result that will respond in the context channel with the specified message components.
+    /// </summary>
+    /// <param name="components"> The message components to respond with. </param>
+    /// <returns>
+    ///     The created command result.
+    /// </returns>
+    protected virtual DiscordTextResponseCommandResult Response(params LocalComponent[] components)
+        => Response(new LocalMessage().WithComponents(components));
 
     /// <summary>
     ///     Returns a result that will respond in the context channel with the specified message.
     /// </summary>
-    /// <param name="message"> The message to reply with. </param>
+    /// <param name="message"> The message to respond with. </param>
     /// <returns>
     ///     The created command result.
     /// </returns>

--- a/src/Disqord.Core/Entities/Local/Message/Embed/LocalEmbed.cs
+++ b/src/Disqord.Core/Entities/Local/Message/Embed/LocalEmbed.cs
@@ -69,7 +69,7 @@ public class LocalEmbed : ILocalConstruct<LocalEmbed>, IJsonConvertible<EmbedJso
             var descriptionLength = Description.GetValueOrDefault()?.Length ?? 0;
             var footerLength = Footer.GetValueOrDefault()?.Length ?? 0;
             var authorLength = Author.GetValueOrDefault()?.Length ?? 0;
-            var fieldsLength = Fields.GetValueOrDefault()?.Sum(static field => @field.Length) ?? 0;
+            var fieldsLength = Fields.GetValueOrDefault()?.Sum(static @field => @field.Length) ?? 0;
             return titleLength + descriptionLength + footerLength + authorLength + fieldsLength;
         }
     }


### PR DESCRIPTION
## Description

This PR adds support for `params LocalComponent[]` in message response methods in both interaction and text module bases.
With the addition of new message components (aka CV2), bot developers may find themselves returning only message components and nothing else as a command response, and may find themselves doing something similar to:
```cs
return Response(new LocalMessage().WithComponents(components));
```
With the addition of the new `Response()`/`Reply()` overloads, this has been simplified to:
```cs
return Response(components);
```

(This PR also sneakily fixes some [assumedly copy-pasted] xmldoc comment inconsistencies between `Reply()` and `Response()` [reply -> respon(d/se) on `Response()`] in the text module base to make it consistent with the interaction module base.)

I am unsure if the addition of another `params T[]` method will cause any breaking changes for some developers since there are now two methods which accept them (`params LocalEmbed[]` and `params LocalComponent[]`).

## Checklist

[//]: # "Put an x in [ ] to check the checkbox, e.g. [x]"

- [x] I discussed this PR with the maintainer(s) prior to opening it.
- [x] I read the [contributing guidelines](https://github.com/Quahu/Disqord/blob/master/.github/CONTRIBUTING.md).
- [x] I tested the changes in this PR.
